### PR TITLE
chore: disable CET compatibility to fix startup/build issues on older Windows

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <RepositoryUrl>https://github.com/STranslate/STranslate/</RepositoryUrl>
+        <CETCompat>false</CETCompat>
 
         <!--// 禁用 SourceLink 功能以避免编译警报 //-->
         <EnableSourceLink>false</EnableSourceLink>


### PR DESCRIPTION
禁用CET保护，增强对旧版本windows系统的兼容性。

> .NET 9运行时默认启用了更严格的控制流执行技术(CET)保护机制
> 旧版本的Windows 10(特别是版本10.0.19041.2546及之前)存在与CET相关的实现缺陷
> 当应用程序尝试在这些旧系统上运行时，系统无法正确处理CET保护，导致启动失败

Microsoft 官方兼容性说明:[.NET 9 中 CET 支持的变更](https://learn.microsoft.com/zh-cn/dotnet/core/compatibility/interop/9.0/cet-support)

在win10 10944.2846上，禁用后程序正常运行.
<img width="986" height="758" alt="image" src="https://github.com/user-attachments/assets/86e38a32-0973-45e1-b7a5-7d89e75cc50b" />
