### PR TITLE
feat: 添加 IPluginContext.ApplyTheme 方法使插件窗口可同步主程序主题

### DIFF
--- a/src/STranslate.Plugin/IPluginContext.cs
+++ b/src/STranslate.Plugin/IPluginContext.cs
@@ -69,4 +69,10 @@ public interface IPluginContext : IDisposable
     /// </summary>
     /// <typeparam name="T">设置存储的类型。</typeparam>
     void SaveSettingStorage<T>() where T : new();
+
+    /// <summary>
+    /// 将当前应用主题应用到指定窗口，使插件窗口与主程序保持一致的视觉风格。
+    /// </summary>
+    /// <param name="window">需要应用主题的窗口实例</param>
+    void ApplyTheme(Window window);
 }

--- a/src/STranslate/Core/PluginContext.cs
+++ b/src/STranslate/Core/PluginContext.cs
@@ -55,6 +55,14 @@ public class PluginContext(PluginMetaData metaData, string serviceId) : IPluginC
 
     public void SaveSettingStorage<T>() where T : new() => Savable?.Save();
 
+    public void ApplyTheme(Window window)
+    {
+        if (window == null)
+            return;
+
+        ThemeManager.SetRequestedTheme(window, Ioc.Default.GetRequiredService<Settings>().ColorScheme);
+    }
+
     public void Dispose()
     {
         Savable.Delete();


### PR DESCRIPTION
- 向IPluginContext接口添加ApplyTheme（Window window）方法。
- 使用 ThemeManager 在 PluginContext 类中实现 ApplyTheme
- 允许插件将主应用主题应用到其自定义窗口
- 已在 自制的 DeepSeekMCP 插件中测试：创建配置对话框，切换主程序亮色/暗色模式，窗口主题均正确跟随。
- 检查了原有 GetPromptEditWindow 不受影响，无回归。
Closes #643
<img width="897" height="651" alt="暗色" src="https://github.com/user-attachments/assets/bf10453b-a864-4f72-8d3b-096ec02651ca" />
<img width="906" height="651" alt="亮色" src="https://github.com/user-attachments/assets/dfed1e91-62e2-44ce-b63a-343e77ffec75" />
