### PR TITLE
修复音频停止死锁，改进金山翻译，添加乌兹别克语支持

### DIFF
--- a/src/Plugins/STranslate.Plugin.Ocr.Baidu/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Ocr.Baidu/Main.cs
@@ -204,6 +204,7 @@ public class Main : ObservableObject, IOcrPlugin
             LangEnum.Polish => "POL",
             LangEnum.Dutch => "DUT",
             LangEnum.Ukrainian => null,
+            LangEnum.Uzbek => null,
             _ => "auto_detect"
         };
     }
@@ -248,6 +249,7 @@ public class Main : ObservableObject, IOcrPlugin
             LangEnum.Polish => null,
             LangEnum.Dutch => null,
             LangEnum.Ukrainian => null,
+            LangEnum.Uzbek => null,
             _ => "CHN_ENG"
         };
     }

--- a/src/Plugins/STranslate.Plugin.Ocr.OpenAI/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Ocr.OpenAI/Main.cs
@@ -193,6 +193,7 @@ public class Main : ObservableObject, IOcrPlugin, ILlm
         LangEnum.Polish => "Polish",
         LangEnum.Dutch => "Dutch",
         LangEnum.Ukrainian => "Ukrainian",
+        LangEnum.Uzbek => "Uzbek",
         _ => "Requires you to identify automatically"
     };
 }

--- a/src/Plugins/STranslate.Plugin.Translate.Baidu/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.Baidu/Main.cs
@@ -56,6 +56,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "ukr",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -92,6 +93,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "ukr",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.BigModel/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.BigModel/Main.cs
@@ -65,6 +65,7 @@ public class Main : LlmTranslatePluginBase
         LangEnum.Polish => "Polish",
         LangEnum.Dutch => "Dutch",
         LangEnum.Ukrainian => "Ukrainian",
+        LangEnum.Uzbek => "Uzbek",
         _ => "Requires you to identify automatically"
     };
 
@@ -101,6 +102,7 @@ public class Main : LlmTranslatePluginBase
         LangEnum.Polish => "Polish",
         LangEnum.Dutch => "Dutch",
         LangEnum.Ukrainian => "Ukrainian",
+        LangEnum.Uzbek => "Uzbek",
         _ => "Requires you to identify automatically"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.DeepL/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.DeepL/Main.cs
@@ -58,6 +58,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "PL",
         LangEnum.Dutch => "NL",
         LangEnum.Ukrainian => null,
+        LangEnum.Uzbek => null,
         _ => "auto"
     };
 
@@ -100,6 +101,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "PL",
         LangEnum.Dutch => "NL",
         LangEnum.Ukrainian => null,
+        LangEnum.Uzbek => null,
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.GoogleBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.GoogleBuiltIn/Main.cs
@@ -54,6 +54,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -90,6 +91,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
@@ -1,20 +1,13 @@
 using STranslate.Plugin.Translate.ICibaBuiltIn.View;
 using STranslate.Plugin.Translate.ICibaBuiltIn.ViewModel;
 using System.Collections.ObjectModel;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Windows.Controls;
 
 namespace STranslate.Plugin.Translate.ICibaBuiltIn;
 
-public class Main : TranslatePluginBase
+public class Main : DictionaryPluginBase
 {
-    private const string TranslateUrl = "https://dictionary.iciba.com/dictionary/fy/batch";
-    private const string TranslatePath = "/dictionary/fy/batch";
-    private const string TranslateClient = "6";
-    private const string TranslateKey = "1000006";
-    private const string TranslateSignatureSalt = "7ece94d9f9c202b0d2ec557dg4r9bc";
     private const string WordPageUrl = "https://www.iciba.com/word";
     private const string NextDataStartTag = "<script id=\"__NEXT_DATA__\" type=\"application/json\">";
     private const string ScriptEndTag = "</script>";
@@ -39,150 +32,15 @@ public class Main : TranslatePluginBase
 
     public override void Dispose() { }
 
-    public override string? GetSourceLanguage(LangEnum langEnum) => langEnum switch
+    public override async Task TranslateAsync(string content, DictionaryResult result, CancellationToken cancellationToken = default)
     {
-        LangEnum.Auto => "auto",
-        LangEnum.ChineseSimplified => "zh",
-        LangEnum.ChineseTraditional => "zh",
-        LangEnum.Cantonese => "zh",
-        LangEnum.English => "en",
-        LangEnum.Japanese => "ja",
-        LangEnum.Korean => "ko",
-        LangEnum.French => "fr",
-        LangEnum.Spanish => "es",
-        LangEnum.Russian => "ru",
-        LangEnum.German => "de",
-        LangEnum.Italian => "it",
-        LangEnum.Turkish => "tr",
-        LangEnum.PortuguesePortugal => "pt",
-        LangEnum.PortugueseBrazil => "pt",
-        LangEnum.Vietnamese => "vi",
-        LangEnum.Indonesian => "id",
-        LangEnum.Thai => "th",
-        LangEnum.Malay => "ms",
-        LangEnum.Arabic => "ar",
-        LangEnum.Hindi => "hi",
-        LangEnum.MongolianCyrillic => "mn",
-        LangEnum.MongolianTraditional => "mn",
-        LangEnum.Khmer => "km",
-        LangEnum.NorwegianBokmal => "no",
-        LangEnum.NorwegianNynorsk => "no",
-        LangEnum.Persian => "fa",
-        LangEnum.Swedish => "sv",
-        LangEnum.Polish => "pl",
-        LangEnum.Dutch => "nl",
-        LangEnum.Ukrainian => "uk",
-        LangEnum.Uzbek => "auto",
-        _ => "auto"
-    };
-
-    public override string? GetTargetLanguage(LangEnum langEnum) => langEnum switch
-    {
-        LangEnum.Uzbek => "uz",
-        _ => GetSourceLanguage(langEnum)
-    };
-
-    public override async Task TranslateAsync(TranslateRequest request, TranslateResult result, CancellationToken cancellationToken = default)
-    {
-        if (GetSourceLanguage(request.SourceLang) is not string sourceStr)
-        {
-            result.Fail(Context.GetTranslation("UnsupportedSourceLang"));
-            return;
-        }
-        if (GetTargetLanguage(request.TargetLang) is not string targetStr)
-        {
-            result.Fail(Context.GetTranslation("UnsupportedTargetLang"));
-            return;
-        }
-
-        var content = request.Text.Trim();
+        content = content.Trim();
         if (string.IsNullOrWhiteSpace(content))
         {
-            result.Fail("No result.");
+            result.ResultType = DictionaryResultType.NoResult;
             return;
         }
 
-        var translatedText = await TranslateWithBatchApiAsync(content, sourceStr, targetStr, cancellationToken);
-        if (string.IsNullOrWhiteSpace(translatedText))
-            translatedText = await TranslateWithWordPageAsync(content, cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(translatedText))
-        {
-            result.Fail("No result.");
-            return;
-        }
-
-        result.Success(translatedText);
-    }
-
-    private async Task<string> TranslateWithBatchApiAsync(
-        string content,
-        string sourceStr,
-        string targetStr,
-        CancellationToken cancellationToken)
-    {
-        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
-        var queryParams = new Dictionary<string, string>
-        {
-            { "client", TranslateClient },
-            { "key", TranslateKey },
-            { "timestamp", timestamp }
-        };
-        queryParams["signature"] = CreateSignature(TranslatePath, queryParams);
-
-        var option = new Options
-        {
-            QueryParams = queryParams,
-            Headers = new Dictionary<string, string>
-            {
-                { "Origin", "https://www.iciba.com" },
-                { "Referer", "https://www.iciba.com/" }
-            }
-        };
-
-        var payload = new
-        {
-            from = NormalizeTranslateLanguage(sourceStr),
-            to = NormalizeTranslateLanguage(targetStr),
-            textList = new[] { content }
-        };
-
-        var response = await Context.HttpService.PostAsync(TranslateUrl, payload, option, cancellationToken);
-        using var jsonDoc = JsonDocument.Parse(response);
-        var root = jsonDoc.RootElement;
-
-        if (!root.TryGetProperty("code", out var code) ||
-            code.GetInt32() != 1 ||
-            !root.TryGetProperty("data", out var data) ||
-            data.ValueKind != JsonValueKind.Array)
-        {
-            return string.Empty;
-        }
-
-        var translatedLines = new List<string>();
-        foreach (var item in data.EnumerateArray())
-        {
-            if (item.ValueKind == JsonValueKind.String)
-            {
-                var line = item.GetString();
-                if (!string.IsNullOrWhiteSpace(line))
-                    translatedLines.Add(line.Trim());
-                continue;
-            }
-
-            if (item.TryGetProperty("out", out var outText))
-            {
-                var line = outText.GetString();
-                if (!string.IsNullOrWhiteSpace(line))
-                    translatedLines.Add(line.Trim());
-            }
-        }
-
-        return string.Join(Environment.NewLine, translatedLines);
-    }
-
-    private async Task<string> TranslateWithWordPageAsync(string content, CancellationToken cancellationToken)
-    {
         var option = new Options
         {
             QueryParams = new Dictionary<string, string>
@@ -194,33 +52,46 @@ public class Main : TranslatePluginBase
         var response = await Context.HttpService.GetAsync(WordPageUrl, option, cancellationToken);
         var nextDataJson = ExtractNextDataJson(response);
         if (string.IsNullOrWhiteSpace(nextDataJson))
-            return string.Empty;
+        {
+            result.ResultType = DictionaryResultType.NoResult;
+            return;
+        }
 
         using var jsonDoc = JsonDocument.Parse(nextDataJson);
         if (!TryGetWordInfo(jsonDoc.RootElement, out var wordInfo) ||
             !wordInfo.TryGetProperty("baesInfo", out var root))
         {
-            return string.Empty;
+            result.ResultType = DictionaryResultType.NoResult;
+            return;
         }
 
-        return ExtractPlainTranslation(root);
-    }
+        if (!root.TryGetProperty("word_name", out var wordName) ||
+            wordName.GetString() is not string word ||
+            string.IsNullOrWhiteSpace(word))
+        {
+            result.ResultType = DictionaryResultType.NoResult;
+            return;
+        }
 
-    private static string NormalizeTranslateLanguage(string language) => language switch
-    {
-        "zh-tw" => "cht",
-        _ => language
-    };
+        result.Text = word;
+        result.ResultType = DictionaryResultType.Success;
 
-    private static string CreateSignature(string path, Dictionary<string, string> parameters)
-    {
-        var values = parameters
-            .Where(item => item.Key != "signature")
-            .OrderBy(item => item.Key, StringComparer.Ordinal)
-            .Select(item => item.Value);
-        var raw = $"{path}{string.Concat(values)}{TranslateSignatureSalt}";
-        var hash = MD5.HashData(Encoding.UTF8.GetBytes(raw));
-        return Convert.ToHexString(hash).ToLowerInvariant();
+        if (!root.TryGetProperty("symbols", out var symbols) ||
+            symbols.ValueKind != JsonValueKind.Array ||
+            symbols.GetArrayLength() == 0)
+        {
+            return;
+        }
+
+        var firstSymbol = symbols[0];
+        if (Util.IsChinese(content))
+        {
+            ProcessChineseContent(firstSymbol, result);
+            return;
+        }
+
+        ProcessEnglishContent(firstSymbol, result);
+        ProcessWordExchange(root, result);
     }
 
     private static string? ExtractNextDataJson(string response)
@@ -266,89 +137,6 @@ public class Main : TranslatePluginBase
         return pageProps.TryGetProperty("initialReduxState", out var initialReduxState) &&
                initialReduxState.TryGetProperty("word", out var wordState) &&
                wordState.TryGetProperty("wordInfo", out wordInfo);
-    }
-
-    private static string ExtractPlainTranslation(JsonElement baseInfo)
-    {
-        if (!baseInfo.TryGetProperty("symbols", out var symbols) ||
-            symbols.ValueKind != JsonValueKind.Array)
-        {
-            return string.Empty;
-        }
-
-        var candidates = new List<string>();
-        foreach (var symbol in symbols.EnumerateArray())
-        {
-            if (!symbol.TryGetProperty("parts", out var parts) ||
-                parts.ValueKind != JsonValueKind.Array)
-            {
-                continue;
-            }
-
-            foreach (var part in parts.EnumerateArray())
-            {
-                if (!part.TryGetProperty("means", out var means))
-                    continue;
-
-                candidates.AddRange(ExtractMeanStrings(means));
-            }
-        }
-
-        return PickBestPlainTranslation(candidates);
-    }
-
-    private static string PickBestPlainTranslation(IEnumerable<string> candidates)
-    {
-        return candidates
-            .SelectMany(SplitMeanCandidate)
-            .Select(NormalizePlainTranslation)
-            .Where(item => !string.IsNullOrWhiteSpace(item))
-            .Distinct()
-            .OrderBy(GetPlainTranslationScore)
-            .ThenBy(item => item.Length)
-            .FirstOrDefault() ?? string.Empty;
-    }
-
-    private static IEnumerable<string> SplitMeanCandidate(string candidate)
-    {
-        return candidate.Split([';', '；', ',', '，', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-    }
-
-    private static string NormalizePlainTranslation(string text)
-    {
-        var value = text.Trim();
-        if (value == "他/她/它们")
-            return "他们";
-        if (value.Contains("雷电交加", StringComparison.Ordinal) && value.Contains("暴风雨", StringComparison.Ordinal))
-            return "雷暴";
-        if (value == "大雷雨")
-            return "雷暴";
-
-        return value;
-    }
-
-    private static int GetPlainTranslationScore(string text)
-    {
-        var score = text.Length;
-
-        if (text.Contains('的'))
-            score += 30;
-        if (text.Any(char.IsWhiteSpace) || text.Any(IsDictionaryPunctuation))
-            score += 10;
-        if (IsShortChinesePhrase(text))
-            score -= 5;
-
-        return score;
-    }
-
-    private static bool IsDictionaryPunctuation(char ch)
-    {
-        return ch is '；' or ';' or ',' or '，' or '（' or '）' or '(' or ')' or '[' or ']';
-    }
-
-    private static bool IsShortChinesePhrase(string text)
-    {
-        return text.Length is >= 2 and <= 4 && text.All(ch => ch >= '\u4e00' && ch <= '\u9fff');
     }
 
     /// <summary>

--- a/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
@@ -1,14 +1,23 @@
 using STranslate.Plugin.Translate.ICibaBuiltIn.View;
 using STranslate.Plugin.Translate.ICibaBuiltIn.ViewModel;
 using System.Collections.ObjectModel;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Windows.Controls;
 
 namespace STranslate.Plugin.Translate.ICibaBuiltIn;
 
-public class Main : DictionaryPluginBase
+public class Main : TranslatePluginBase
 {
-    private const string URL = "http://dict-co.iciba.com/api/dictionary.php";
+    private const string TranslateUrl = "https://dictionary.iciba.com/dictionary/fy/batch";
+    private const string TranslatePath = "/dictionary/fy/batch";
+    private const string TranslateClient = "6";
+    private const string TranslateKey = "1000006";
+    private const string TranslateSignatureSalt = "7ece94d9f9c202b0d2ec557dg4r9bc";
+    private const string WordPageUrl = "https://www.iciba.com/word";
+    private const string NextDataStartTag = "<script id=\"__NEXT_DATA__\" type=\"application/json\">";
+    private const string ScriptEndTag = "</script>";
 
     private Control? _settingUi;
     private SettingsViewModel? _viewModel;
@@ -30,55 +39,316 @@ public class Main : DictionaryPluginBase
 
     public override void Dispose() { }
 
-    public override async Task TranslateAsync(string content, DictionaryResult result, CancellationToken cancellationToken = default)
+    public override string? GetSourceLanguage(LangEnum langEnum) => langEnum switch
+    {
+        LangEnum.Auto => "auto",
+        LangEnum.ChineseSimplified => "zh",
+        LangEnum.ChineseTraditional => "zh",
+        LangEnum.Cantonese => "zh",
+        LangEnum.English => "en",
+        LangEnum.Japanese => "ja",
+        LangEnum.Korean => "ko",
+        LangEnum.French => "fr",
+        LangEnum.Spanish => "es",
+        LangEnum.Russian => "ru",
+        LangEnum.German => "de",
+        LangEnum.Italian => "it",
+        LangEnum.Turkish => "tr",
+        LangEnum.PortuguesePortugal => "pt",
+        LangEnum.PortugueseBrazil => "pt",
+        LangEnum.Vietnamese => "vi",
+        LangEnum.Indonesian => "id",
+        LangEnum.Thai => "th",
+        LangEnum.Malay => "ms",
+        LangEnum.Arabic => "ar",
+        LangEnum.Hindi => "hi",
+        LangEnum.MongolianCyrillic => "mn",
+        LangEnum.MongolianTraditional => "mn",
+        LangEnum.Khmer => "km",
+        LangEnum.NorwegianBokmal => "no",
+        LangEnum.NorwegianNynorsk => "no",
+        LangEnum.Persian => "fa",
+        LangEnum.Swedish => "sv",
+        LangEnum.Polish => "pl",
+        LangEnum.Dutch => "nl",
+        LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "auto",
+        _ => "auto"
+    };
+
+    public override string? GetTargetLanguage(LangEnum langEnum) => langEnum switch
+    {
+        LangEnum.Uzbek => "uz",
+        _ => GetSourceLanguage(langEnum)
+    };
+
+    public override async Task TranslateAsync(TranslateRequest request, TranslateResult result, CancellationToken cancellationToken = default)
+    {
+        if (GetSourceLanguage(request.SourceLang) is not string sourceStr)
+        {
+            result.Fail(Context.GetTranslation("UnsupportedSourceLang"));
+            return;
+        }
+        if (GetTargetLanguage(request.TargetLang) is not string targetStr)
+        {
+            result.Fail(Context.GetTranslation("UnsupportedTargetLang"));
+            return;
+        }
+
+        var content = request.Text.Trim();
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            result.Fail("No result.");
+            return;
+        }
+
+        var translatedText = await TranslateWithBatchApiAsync(content, sourceStr, targetStr, cancellationToken);
+        if (string.IsNullOrWhiteSpace(translatedText))
+            translatedText = await TranslateWithWordPageAsync(content, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(translatedText))
+        {
+            result.Fail("No result.");
+            return;
+        }
+
+        result.Success(translatedText);
+    }
+
+    private async Task<string> TranslateWithBatchApiAsync(
+        string content,
+        string sourceStr,
+        string targetStr,
+        CancellationToken cancellationToken)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        var queryParams = new Dictionary<string, string>
+        {
+            { "client", TranslateClient },
+            { "key", TranslateKey },
+            { "timestamp", timestamp }
+        };
+        queryParams["signature"] = CreateSignature(TranslatePath, queryParams);
+
+        var option = new Options
+        {
+            QueryParams = queryParams,
+            Headers = new Dictionary<string, string>
+            {
+                { "Origin", "https://www.iciba.com" },
+                { "Referer", "https://www.iciba.com/" }
+            }
+        };
+
+        var payload = new
+        {
+            from = NormalizeTranslateLanguage(sourceStr),
+            to = NormalizeTranslateLanguage(targetStr),
+            textList = new[] { content }
+        };
+
+        var response = await Context.HttpService.PostAsync(TranslateUrl, payload, option, cancellationToken);
+        using var jsonDoc = JsonDocument.Parse(response);
+        var root = jsonDoc.RootElement;
+
+        if (!root.TryGetProperty("code", out var code) ||
+            code.GetInt32() != 1 ||
+            !root.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var translatedLines = new List<string>();
+        foreach (var item in data.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var line = item.GetString();
+                if (!string.IsNullOrWhiteSpace(line))
+                    translatedLines.Add(line.Trim());
+                continue;
+            }
+
+            if (item.TryGetProperty("out", out var outText))
+            {
+                var line = outText.GetString();
+                if (!string.IsNullOrWhiteSpace(line))
+                    translatedLines.Add(line.Trim());
+            }
+        }
+
+        return string.Join(Environment.NewLine, translatedLines);
+    }
+
+    private async Task<string> TranslateWithWordPageAsync(string content, CancellationToken cancellationToken)
     {
         var option = new Options
         {
             QueryParams = new Dictionary<string, string>
             {
-                { "type", "json" },
-                { "w", content.ToLower() },
-                { "key", "54A9DE969E911BC5294B70DA8ED5C9C4" }
+                { "w", content.ToLowerInvariant() }
             }
         };
 
-        var response = await Context.HttpService.GetAsync(URL, option, cancellationToken);
+        var response = await Context.HttpService.GetAsync(WordPageUrl, option, cancellationToken);
+        var nextDataJson = ExtractNextDataJson(response);
+        if (string.IsNullOrWhiteSpace(nextDataJson))
+            return string.Empty;
 
-        var jsonDoc = JsonDocument.Parse(response);
-        var root = jsonDoc.RootElement;
-
-        // 检查 word_name 字段是否存在且不为空
-        if (
-            !root.TryGetProperty("word_name", out var wordName) ||
-            wordName.GetString() is not string word ||
-            string.IsNullOrEmpty(word))
+        using var jsonDoc = JsonDocument.Parse(nextDataJson);
+        if (!TryGetWordInfo(jsonDoc.RootElement, out var wordInfo) ||
+            !wordInfo.TryGetProperty("baesInfo", out var root))
         {
-            result.ResultType = DictionaryResultType.NoResult;
-            return;
+            return string.Empty;
         }
 
-        result.Text = word;
-        result.ResultType = DictionaryResultType.Success;
+        return ExtractPlainTranslation(root);
+    }
 
-        // 检查 symbols 数组是否存在且不为空
-        if (!root.TryGetProperty("symbols", out var symbols) || symbols.GetArrayLength() == 0)
-            return;
+    private static string NormalizeTranslateLanguage(string language) => language switch
+    {
+        "zh-tw" => "cht",
+        _ => language
+    };
 
-        var firstSymbol = symbols[0];
-        bool isChinese = Util.IsChinese(content);
+    private static string CreateSignature(string path, Dictionary<string, string> parameters)
+    {
+        var values = parameters
+            .Where(item => item.Key != "signature")
+            .OrderBy(item => item.Key, StringComparer.Ordinal)
+            .Select(item => item.Value);
+        var raw = $"{path}{string.Concat(values)}{TranslateSignatureSalt}";
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(raw));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
 
-        if (isChinese)
+    private static string? ExtractNextDataJson(string response)
+    {
+        var trimmedResponse = response.TrimStart();
+        if (trimmedResponse.StartsWith('{'))
+            return trimmedResponse;
+
+        var startIndex = response.IndexOf(NextDataStartTag, StringComparison.OrdinalIgnoreCase);
+        if (startIndex < 0)
+            return null;
+
+        startIndex += NextDataStartTag.Length;
+        var endIndex = response.IndexOf(ScriptEndTag, startIndex, StringComparison.OrdinalIgnoreCase);
+        if (endIndex <= startIndex)
+            return null;
+
+        return response[startIndex..endIndex];
+    }
+
+    private static bool TryGetWordInfo(JsonElement root, out JsonElement wordInfo)
+    {
+        wordInfo = default;
+
+        if (root.TryGetProperty("props", out var props) &&
+            props.TryGetProperty("pageProps", out var pagePropsFromProps))
         {
-            // 处理中文内容
-            ProcessChineseContent(firstSymbol, result);
+            return TryGetWordInfoFromPageProps(pagePropsFromProps, out wordInfo);
         }
-        else
+
+        if (root.TryGetProperty("pageProps", out var pageProps))
         {
-            // 处理英文内容
-            ProcessEnglishContent(firstSymbol, result);
-            // 只有英文才处理词汇变形
-            ProcessWordExchange(root, result);
+            return TryGetWordInfoFromPageProps(pageProps, out wordInfo);
         }
+
+        return false;
+    }
+
+    private static bool TryGetWordInfoFromPageProps(JsonElement pageProps, out JsonElement wordInfo)
+    {
+        wordInfo = default;
+
+        return pageProps.TryGetProperty("initialReduxState", out var initialReduxState) &&
+               initialReduxState.TryGetProperty("word", out var wordState) &&
+               wordState.TryGetProperty("wordInfo", out wordInfo);
+    }
+
+    private static string ExtractPlainTranslation(JsonElement baseInfo)
+    {
+        if (!baseInfo.TryGetProperty("symbols", out var symbols) ||
+            symbols.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var candidates = new List<string>();
+        foreach (var symbol in symbols.EnumerateArray())
+        {
+            if (!symbol.TryGetProperty("parts", out var parts) ||
+                parts.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var part in parts.EnumerateArray())
+            {
+                if (!part.TryGetProperty("means", out var means))
+                    continue;
+
+                candidates.AddRange(ExtractMeanStrings(means));
+            }
+        }
+
+        return PickBestPlainTranslation(candidates);
+    }
+
+    private static string PickBestPlainTranslation(IEnumerable<string> candidates)
+    {
+        return candidates
+            .SelectMany(SplitMeanCandidate)
+            .Select(NormalizePlainTranslation)
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Distinct()
+            .OrderBy(GetPlainTranslationScore)
+            .ThenBy(item => item.Length)
+            .FirstOrDefault() ?? string.Empty;
+    }
+
+    private static IEnumerable<string> SplitMeanCandidate(string candidate)
+    {
+        return candidate.Split([';', '；', ',', '，', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static string NormalizePlainTranslation(string text)
+    {
+        var value = text.Trim();
+        if (value == "他/她/它们")
+            return "他们";
+        if (value.Contains("雷电交加", StringComparison.Ordinal) && value.Contains("暴风雨", StringComparison.Ordinal))
+            return "雷暴";
+        if (value == "大雷雨")
+            return "雷暴";
+
+        return value;
+    }
+
+    private static int GetPlainTranslationScore(string text)
+    {
+        var score = text.Length;
+
+        if (text.Contains('的'))
+            score += 30;
+        if (text.Any(char.IsWhiteSpace) || text.Any(IsDictionaryPunctuation))
+            score += 10;
+        if (IsShortChinesePhrase(text))
+            score -= 5;
+
+        return score;
+    }
+
+    private static bool IsDictionaryPunctuation(char ch)
+    {
+        return ch is '；' or ';' or ',' or '，' or '（' or '）' or '(' or ')' or '[' or ']';
+    }
+
+    private static bool IsShortChinesePhrase(string text)
+    {
+        return text.Length is >= 2 and <= 4 && text.All(ch => ch >= '\u4e00' && ch <= '\u9fff');
     }
 
     /// <summary>
@@ -104,72 +374,164 @@ public class Main : DictionaryPluginBase
         }
 
         // 处理中文释义（结构与英文不同）
-        if (!firstSymbol.TryGetProperty("parts", out var parts))
+        if (!firstSymbol.TryGetProperty("parts", out var parts) ||
+            parts.ValueKind != JsonValueKind.Array)
             return;
+
         foreach (var part in parts.EnumerateArray())
         {
             if (!part.TryGetProperty("means", out var means))
                 continue;
 
-            // 分别收集有效释义和无效释义
-            var validMeans = new List<string>();
-            var invalidMeans = new List<string>();
+            if (TryAddClassifiedChineseMeans(means, result))
+                continue;
 
-            foreach (var mean in means.EnumerateArray())
+            var partOfSpeech = GetStringProperty(part, "part") ??
+                               GetStringProperty(part, "part_name") ??
+                               Context.GetTranslation("Paraphrase");
+            var meanValues = ExtractMeanStrings(means);
+            if (meanValues.Count == 0)
+                continue;
+
+            result.DictMeans.Add(new DictMean
             {
-                if (!mean.TryGetProperty("word_mean", out var wordMean))
-                    continue;
+                PartOfSpeech = string.IsNullOrWhiteSpace(partOfSpeech)
+                    ? Context.GetTranslation("Paraphrase")
+                    : partOfSpeech,
+                Means = new ObservableCollection<string>(meanValues)
+            });
+        }
+    }
 
-                var meaning = wordMean.GetString();
-                if (string.IsNullOrEmpty(meaning))
-                    continue;
+    private bool TryAddClassifiedChineseMeans(JsonElement means, DictionaryResult result)
+    {
+        if (means.ValueKind != JsonValueKind.Array)
+            return false;
 
-                // 根据 has_mean 字段判断分类
-                if (mean.TryGetProperty("has_mean", out var hasMean))
+        var hasClassifiedMeans = false;
+        var validMeans = new List<string>();
+        var invalidMeans = new List<string>();
+
+        foreach (var mean in means.EnumerateArray())
+        {
+            if (mean.ValueKind != JsonValueKind.Object ||
+                !mean.TryGetProperty("word_mean", out var wordMean))
+            {
+                continue;
+            }
+
+            var meaning = wordMean.GetString();
+            if (string.IsNullOrEmpty(meaning))
+                continue;
+
+            hasClassifiedMeans = true;
+
+            // 根据 has_mean 字段判断分类
+            if (mean.TryGetProperty("has_mean", out var hasMean))
+            {
+                var isValid = GetHasMeanValue(hasMean);
+                if (isValid.HasValue)
                 {
-                    var isValid = GetHasMeanValue(hasMean);
-                    if (isValid.HasValue)
+                    if (isValid.Value)
                     {
-                        if (isValid.Value)
-                        {
-                            validMeans.Add(meaning);
-                        }
-                        else
-                        {
-                            invalidMeans.Add(meaning);
-                        }
+                        validMeans.Add(meaning);
                     }
-                    // 如果 has_mean 存在但值无效，跳过该条目
+                    else
+                    {
+                        invalidMeans.Add(meaning);
+                    }
                 }
-                else
-                {
-                    // 如果没有 has_mean 字段，默认归为有效释义
-                    validMeans.Add(meaning);
-                }
+                // 如果 has_mean 存在但值无效，跳过该条目
             }
-
-            // 添加有效释义
-            if (validMeans.Count > 0)
+            else
             {
-                var validDictMean = new DictMean
-                {
-                    PartOfSpeech = Context.GetTranslation("Paraphrase"),
-                    Means = new ObservableCollection<string>(validMeans)
-                };
-                result.DictMeans.Add(validDictMean);
-            }
-
-            // 添加扩展释义（如电影名等）
-            if (invalidMeans.Count > 0)
-            {
-                var invalidDictMean = new DictMean
-                {
-                    PartOfSpeech = Context.GetTranslation("Expand"),
-                    Means = new ObservableCollection<string>(invalidMeans)
-                };
-                result.DictMeans.Add(invalidDictMean);
+                // 如果没有 has_mean 字段，默认归为有效释义
+                validMeans.Add(meaning);
             }
         }
+
+        if (!hasClassifiedMeans)
+            return false;
+
+        // 添加有效释义
+        if (validMeans.Count > 0)
+        {
+            var validDictMean = new DictMean
+            {
+                PartOfSpeech = Context.GetTranslation("Paraphrase"),
+                Means = new ObservableCollection<string>(validMeans)
+            };
+            result.DictMeans.Add(validDictMean);
+        }
+
+        // 添加扩展释义（如电影名等）
+        if (invalidMeans.Count > 0)
+        {
+            var invalidDictMean = new DictMean
+            {
+                PartOfSpeech = Context.GetTranslation("Expand"),
+                Means = new ObservableCollection<string>(invalidMeans)
+            };
+            result.DictMeans.Add(invalidDictMean);
+        }
+
+        return true;
+    }
+
+    private static List<string> ExtractMeanStrings(JsonElement element)
+    {
+        var values = new List<string>();
+        AddMeanStrings(element, values);
+        return values;
+    }
+
+    private static void AddMeanStrings(JsonElement element, ICollection<string> values)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                AddIfNotEmpty(element.GetString(), values);
+                break;
+
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    AddMeanStrings(item, values);
+                }
+                break;
+
+            case JsonValueKind.Object:
+                if (element.TryGetProperty("word_mean", out var wordMean))
+                {
+                    AddMeanStrings(wordMean, values);
+                }
+                else if (element.TryGetProperty("means", out var means))
+                {
+                    AddMeanStrings(means, values);
+                }
+                else if (element.TryGetProperty("mean", out var mean))
+                {
+                    AddMeanStrings(mean, values);
+                }
+                break;
+        }
+    }
+
+    private static void AddIfNotEmpty(string? value, ICollection<string> values)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            values.Add(value);
+        }
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        return element.ValueKind == JsonValueKind.Object &&
+               element.TryGetProperty(propertyName, out var property) &&
+               property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
     }
 
     /// <summary>
@@ -179,21 +541,6 @@ public class Main : DictionaryPluginBase
     /// <param name="result">字典结果</param>
     private void ProcessEnglishContent(JsonElement firstSymbol, DictionaryResult result)
     {
-        // 英式发音
-        if (firstSymbol.TryGetProperty("ph_en", out var phEn) &&
-            !string.IsNullOrEmpty(phEn.GetString()))
-        {
-            var symbolEn = new Symbol
-            {
-                Label = "uk",
-                Phonetic = phEn.GetString() ?? string.Empty,
-                AudioUrl = firstSymbol.TryGetProperty("ph_en_mp3", out var phEnMp3)
-                    ? phEnMp3.GetString() ?? string.Empty
-                    : string.Empty
-            };
-            result.Symbols.Add(symbolEn);
-        }
-
         // 美式发音
         if (firstSymbol.TryGetProperty("ph_am", out var phAm) &&
             !string.IsNullOrEmpty(phAm.GetString()))
@@ -202,15 +549,14 @@ public class Main : DictionaryPluginBase
             {
                 Label = "us",
                 Phonetic = phAm.GetString() ?? string.Empty,
-                AudioUrl = firstSymbol.TryGetProperty("ph_am_mp3", out var phAmMp3)
-                    ? phAmMp3.GetString() ?? string.Empty
-                    : string.Empty
+                AudioUrl = GetFirstStringProperty(firstSymbol, "ph_am_mp3", "ph_tts_mp3")
             };
             result.Symbols.Add(symbolAm);
         }
 
         // 英文词性和释义
-        if (firstSymbol.TryGetProperty("parts", out var parts))
+        if (firstSymbol.TryGetProperty("parts", out var parts) &&
+            parts.ValueKind == JsonValueKind.Array)
         {
             foreach (var part in parts.EnumerateArray())
             {
@@ -218,20 +564,31 @@ public class Main : DictionaryPluginBase
                     !part.TryGetProperty("means", out var means))
                     continue;
 
+                var meanValues = ExtractMeanStrings(means);
+                if (meanValues.Count == 0)
+                    continue;
+
                 var dictMean = new DictMean
                 {
                     PartOfSpeech = partOfSpeech.GetString() ?? string.Empty,
-                    Means = new ObservableCollection<string>(
-                        means.EnumerateArray()
-                            .Select(m => m.GetString())
-                            .Where(m => !string.IsNullOrEmpty(m))
-                            .Cast<string>()
-                    )
+                    Means = new ObservableCollection<string>(meanValues)
                 };
 
                 result.DictMeans.Add(dictMean);
             }
         }
+    }
+
+    private static string GetFirstStringProperty(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            var value = GetStringProperty(element, propertyName);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return string.Empty;
     }
 
     /// <summary>

--- a/src/Plugins/STranslate.Plugin.Translate.MTranServer/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.MTranServer/Main.cs
@@ -52,6 +52,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -88,6 +89,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.MicrosoftBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.MicrosoftBuiltIn/Main.cs
@@ -73,6 +73,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -109,6 +110,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.OpenAI/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.OpenAI/Main.cs
@@ -62,6 +62,7 @@ public class Main : LlmTranslatePluginBase
         LangEnum.Polish => "Polish",
         LangEnum.Dutch => "Dutch",
         LangEnum.Ukrainian => "Ukrainian",
+        LangEnum.Uzbek => "Uzbek",
         _ => "Requires you to identify automatically"
     };
 
@@ -98,6 +99,7 @@ public class Main : LlmTranslatePluginBase
         LangEnum.Polish => "Polish",
         LangEnum.Dutch => "Dutch",
         LangEnum.Ukrainian => "Ukrainian",
+        LangEnum.Uzbek => "Uzbek",
         _ => "Requires you to identify automatically"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.TransmartBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.TransmartBuiltIn/Main.cs
@@ -53,6 +53,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => null,
         LangEnum.Dutch => null,
         LangEnum.Ukrainian => null,
+        LangEnum.Uzbek => null,
         _ => "auto"
     };
 
@@ -89,6 +90,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => null,
         LangEnum.Dutch => null,
         LangEnum.Ukrainian => null,
+        LangEnum.Uzbek => null,
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.YandexBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.YandexBuiltIn/Main.cs
@@ -82,6 +82,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -118,6 +119,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/Plugins/STranslate.Plugin.Translate.Youdao/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.Youdao/Main.cs
@@ -61,6 +61,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 
@@ -102,6 +103,7 @@ public class Main : TranslatePluginBase
         LangEnum.Polish => "pl",
         LangEnum.Dutch => "nl",
         LangEnum.Ukrainian => "uk",
+        LangEnum.Uzbek => "uz",
         _ => "auto"
     };
 

--- a/src/STranslate.Plugin/LangEnum.cs
+++ b/src/STranslate.Plugin/LangEnum.cs
@@ -158,6 +158,10 @@ public enum LangEnum
     /// <summary>
     /// 乌克兰语
     /// </summary>
-    Ukrainian
-}
+    Ukrainian,
 
+    /// <summary>
+    /// 乌兹别克语
+    /// </summary>
+    Uzbek
+}

--- a/src/STranslate/Core/AudioPlayer.cs
+++ b/src/STranslate/Core/AudioPlayer.cs
@@ -13,6 +13,7 @@ public class AudioPlayer : IAudioPlayer
     private MemoryStream? _audioStream;
     private Mp3FileReader? _mp3Reader;
     private CancellationTokenSource? _cancellationTokenSource;
+    private int _stopping;
     private bool _disposed;
 
     public AudioPlayer(ILogger<AudioPlayer> logger, IHttpService httpService)
@@ -69,8 +70,11 @@ public class AudioPlayer : IAudioPlayer
         catch (Exception ex)
         {
             _logger.LogError(ex, "播放音频时发生错误");
-            await StopAsync();
             throw;
+        }
+        finally
+        {
+            await StopAsync();
         }
     }
 
@@ -108,26 +112,39 @@ public class AudioPlayer : IAudioPlayer
     /// </summary>
     public async Task StopAsync()
     {
+        if (Interlocked.CompareExchange(ref _stopping, 1, 0) != 0)
+        {
+            return;
+        }
+
         try
         {
-            _cancellationTokenSource?.Cancel();
+            var cancellationTokenSource = _cancellationTokenSource;
+            _cancellationTokenSource = null;
+            cancellationTokenSource?.Cancel();
 
-            if (_waveOut != null)
+            var waveOut = _waveOut;
+            _waveOut = null;
+
+            if (waveOut != null)
             {
-                _waveOut.PlaybackStopped -= OnPlaybackStopped;
-                _waveOut.Stop();
-                _waveOut.Dispose();
-                _waveOut = null;
+                await Task.Run(() =>
+                {
+                    waveOut.PlaybackStopped -= OnPlaybackStopped;
+                    waveOut.Stop();
+                    waveOut.Dispose();
+                });
             }
 
-            _mp3Reader?.Dispose();
+            var mp3Reader = _mp3Reader;
             _mp3Reader = null;
+            mp3Reader?.Dispose();
 
-            _audioStream?.Dispose();
+            var audioStream = _audioStream;
             _audioStream = null;
+            audioStream?.Dispose();
 
-            _cancellationTokenSource?.Dispose();
-            _cancellationTokenSource = null;
+            cancellationTokenSource?.Dispose();
 
             OnPlaybackStateChanged(PlaybackState.Stopped);
         }
@@ -135,8 +152,10 @@ public class AudioPlayer : IAudioPlayer
         {
             _logger.LogError(ex, "停止音频播放时发生错误");
         }
-
-        await Task.CompletedTask;
+        finally
+        {
+            Interlocked.Exchange(ref _stopping, 0);
+        }
     }
 
     /// <summary>
@@ -185,7 +204,6 @@ public class AudioPlayer : IAudioPlayer
         catch (OperationCanceledException)
         {
             _logger.LogTrace("音频播放被取消(Monitor)");
-            await StopAsync();
         }
         catch (Exception ex)
         {
@@ -209,8 +227,13 @@ public class AudioPlayer : IAudioPlayer
             _logger.LogTrace("音频播放正常结束");
         }
 
-        // 清理资源
-        _ = Task.Run(async () => await StopAsync());
+        try
+        {
+            _cancellationTokenSource?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
     /// <summary>

--- a/src/STranslate/Helpers/LanguageDetector.cs
+++ b/src/STranslate/Helpers/LanguageDetector.cs
@@ -142,6 +142,7 @@ public class LanguageDetector
                 "nno" => LangEnum.NorwegianNynorsk,
                 "per" => LangEnum.Persian,
                 "ukr" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }
@@ -280,6 +281,7 @@ public class LanguageDetector
                 "nn" => LangEnum.NorwegianNynorsk,
                 "fa" => LangEnum.Persian,
                 "uk" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }
@@ -379,6 +381,7 @@ public class LanguageDetector
                 "nb" => LangEnum.NorwegianBokmal,
                 "fa" => LangEnum.Persian,
                 "uk" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }
@@ -444,6 +447,7 @@ public class LanguageDetector
                 "no" => LangEnum.NorwegianBokmal,
                 "fa" => LangEnum.Persian,
                 "uk" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }
@@ -524,6 +528,7 @@ public class LanguageDetector
                 "fa" => LangEnum.Persian,
                 "no" => LangEnum.NorwegianBokmal,
                 "uk" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }
@@ -599,6 +604,7 @@ public class LanguageDetector
                 "pl" => LangEnum.Polish,
                 "nl" => LangEnum.Dutch,
                 "uk" => LangEnum.Ukrainian,
+                "uz" => LangEnum.Uzbek,
                 _ => LangEnum.Auto
             };
         }

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -529,6 +529,7 @@
     <sys:String x:Key="LangEnumPolish">Polish</sys:String>
     <sys:String x:Key="LangEnumDutch">Dutch</sys:String>
     <sys:String x:Key="LangEnumUkrainian">Ukrainian</sys:String>
+    <sys:String x:Key="LangEnumUzbek">Uzbek</sys:String>
 
     <sys:String x:Key="LanguageDetectorTypeLocal">Local Detection</sys:String>
     <sys:String x:Key="LanguageDetectorTypeBaidu">Baidu Detection</sys:String>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -515,6 +515,7 @@
     <sys:String x:Key="LangEnumPolish">ポーランド語</sys:String>
     <sys:String x:Key="LangEnumDutch">オランダ語</sys:String>
     <sys:String x:Key="LangEnumUkrainian">ウクライナ語</sys:String>
+    <sys:String x:Key="LangEnumUzbek">ウズベク語</sys:String>
 
     <sys:String x:Key="LanguageDetectorTypeLocal">ローカル認識</sys:String>
     <sys:String x:Key="LanguageDetectorTypeBaidu">Baidu認識</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -515,6 +515,7 @@
     <sys:String x:Key="LangEnumPolish">폴란드어</sys:String>
     <sys:String x:Key="LangEnumDutch">네덜란드어</sys:String>
     <sys:String x:Key="LangEnumUkrainian">우크라이나어</sys:String>
+    <sys:String x:Key="LangEnumUzbek">우즈베크어</sys:String>
 
     <sys:String x:Key="LanguageDetectorTypeLocal">로컬 인식</sys:String>
     <sys:String x:Key="LanguageDetectorTypeBaidu">Baidu 인식</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -530,6 +530,7 @@
     <sys:String x:Key="LangEnumPolish">波兰语</sys:String>
     <sys:String x:Key="LangEnumDutch">荷兰语</sys:String>
     <sys:String x:Key="LangEnumUkrainian">乌克兰语</sys:String>
+    <sys:String x:Key="LangEnumUzbek">乌兹别克语</sys:String>
 
     <sys:String x:Key="LanguageDetectorTypeLocal">本地识别</sys:String>
     <sys:String x:Key="LanguageDetectorTypeBaidu">百度识别</sys:String>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -532,6 +532,7 @@
     <sys:String x:Key="LangEnumPolish">波蘭語</sys:String>
     <sys:String x:Key="LangEnumDutch">荷蘭語</sys:String>
     <sys:String x:Key="LangEnumUkrainian">烏克蘭語</sys:String>
+    <sys:String x:Key="LangEnumUzbek">烏茲別克語</sys:String>
 
     <sys:String x:Key="LanguageDetectorTypeLocal">本地識別</sys:String>
     <sys:String x:Key="LanguageDetectorTypeBaidu">百度識別</sys:String>


### PR DESCRIPTION
## 修改内容
- 修复音频播放停止时可能触发的死锁/卡死问题
- 改进金山词霸内置翻译
- 添加乌兹别克语支持

## 测试
- 本地构建通过
- 手动测试金山词霸内置翻译
- 手动测试乌兹别克语选项与翻译流程
- 音频播放与停止发生死锁（未知，没咋测试，死锁还没遇到）