### PR TITLE
fix: harden iCIBA built-in page parsing | 修正 金山词霸（内置） 翻译失败问题

### DIFF
--- a/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using STranslate.Plugin.Translate.ICibaBuiltIn.View;
 using STranslate.Plugin.Translate.ICibaBuiltIn.ViewModel;
 using System.Collections.ObjectModel;

--- a/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Translate.ICibaBuiltIn/Main.cs
@@ -9,8 +9,9 @@ namespace STranslate.Plugin.Translate.ICibaBuiltIn;
 public class Main : DictionaryPluginBase
 {
     private const string WordPageUrl = "https://www.iciba.com/word";
-    private const string NextDataStartTag = "<script id=\"__NEXT_DATA__\" type=\"application/json\">";
+    private const string ScriptStartTag = "<script";
     private const string ScriptEndTag = "</script>";
+    private const string NextDataScriptId = "__NEXT_DATA__";
 
     private Control? _settingUi;
     private SettingsViewModel? _viewModel;
@@ -57,7 +58,13 @@ public class Main : DictionaryPluginBase
             return;
         }
 
-        using var jsonDoc = JsonDocument.Parse(nextDataJson);
+        using var jsonDoc = ParseNextDataJson(nextDataJson, content);
+        if (jsonDoc is null)
+        {
+            result.ResultType = DictionaryResultType.NoResult;
+            return;
+        }
+
         if (!TryGetWordInfo(jsonDoc.RootElement, out var wordInfo) ||
             !wordInfo.TryGetProperty("baesInfo", out var root))
         {
@@ -106,19 +113,56 @@ public class Main : DictionaryPluginBase
     private static string? ExtractNextDataJson(string response)
     {
         var trimmedResponse = response.TrimStart();
-        if (trimmedResponse.StartsWith('{'))
+        if (IsJsonPayload(trimmedResponse))
             return trimmedResponse;
 
-        var startIndex = response.IndexOf(NextDataStartTag, StringComparison.OrdinalIgnoreCase);
-        if (startIndex < 0)
-            return null;
+        var searchIndex = 0;
+        while (searchIndex < response.Length)
+        {
+            var scriptStartIndex = response.IndexOf(ScriptStartTag, searchIndex, StringComparison.OrdinalIgnoreCase);
+            if (scriptStartIndex < 0)
+                return null;
 
-        startIndex += NextDataStartTag.Length;
-        var endIndex = response.IndexOf(ScriptEndTag, startIndex, StringComparison.OrdinalIgnoreCase);
-        if (endIndex <= startIndex)
-            return null;
+            var startTagEndIndex = response.IndexOf('>', scriptStartIndex);
+            if (startTagEndIndex < 0)
+                return null;
 
-        return response[startIndex..endIndex];
+            var startTag = response[scriptStartIndex..startTagEndIndex];
+            if (!startTag.Contains(NextDataScriptId, StringComparison.OrdinalIgnoreCase))
+            {
+                searchIndex = startTagEndIndex + 1;
+                continue;
+            }
+
+            var contentStartIndex = startTagEndIndex + 1;
+            var scriptEndIndex = response.IndexOf(ScriptEndTag, contentStartIndex, StringComparison.OrdinalIgnoreCase);
+            if (scriptEndIndex <= contentStartIndex)
+                return null;
+
+            var scriptContent = response[contentStartIndex..scriptEndIndex].Trim();
+            return IsJsonPayload(scriptContent) ? scriptContent : null;
+        }
+
+        return null;
+    }
+
+    private JsonDocument? ParseNextDataJson(string nextDataJson, string content)
+    {
+        try
+        {
+            return JsonDocument.Parse(nextDataJson);
+        }
+        catch (JsonException ex)
+        {
+            Context.Logger.LogWarning(ex, "Failed to parse iCIBA __NEXT_DATA__ for content: {Content}", content);
+            return null;
+        }
+    }
+
+    private static bool IsJsonPayload(string value)
+    {
+        var trimmedValue = value.TrimStart();
+        return trimmedValue.StartsWith('{') || trimmedValue.StartsWith('[');
     }
 
     private static bool TryGetWordInfo(JsonElement root, out JsonElement wordInfo)


### PR DESCRIPTION

This PR hardens the `iCIBA (Built-in)` dictionary plugin parsing flow.
修复 `iCIBA (Built-in)` 在解析金山词霸页面时，因 `__NEXT_DATA__` 提取不稳定或内容不是合法 JSON，导致 UI 显示类似以下错误的问题：

```text
翻译失败: '<' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0.
```

**当前版本 v2.0.6 portable**
<img width="757" height="558" alt="image" src="https://github.com/user-attachments/assets/a4e4893b-1681-488d-b075-0ed35bba0caf" />

**修复后**
<img width="749" height="773" alt="image" src="https://github.com/user-attachments/assets/88cffd20-5c15-48ba-af8b-ecc79a7dd534" />
