### PR TITLE
fix: localize OCR service notifications | 修复 "无法获取OCR服务" 提示的本地化

### DIFF
--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -746,6 +746,13 @@
     <sys:String x:Key="TtsServiceNotFound">No TTS service configured, please go to "Settings-Services-TTS" to configure</sys:String>
     <sys:String x:Key="ImtransFailed">Image translation failed</sys:String>
     <sys:String x:Key="NoTranslateService">No available translation service found</sys:String>
+    <sys:String x:Key="GoToSettings">Go to settings</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundTitle">Unable to get image translation service</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundMessage">Image translation service is not configured or enabled. Go to "Settings-Services-Text Translation" to configure it before using this feature.</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundTitle">Unable to get OCR service</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundMessage">OCR service is not configured or enabled. Go to "Settings-Services-Text Recognition" to configure it before using this feature.</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundTitle">Unable to get image translation OCR service</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundMessage">Image translation OCR service is not configured and no OCR service is available. Go to "Settings-Services-Text Recognition" to configure one.</sys:String>
     <sys:String x:Key="NavigateFailed">Already at the end</sys:String>
     <sys:String x:Key="NoValidPluginFile">No SPKG File</sys:String>
 

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -726,6 +726,13 @@
     <sys:String x:Key="TtsServiceNotFound">音声合成サービスが設定されていません。「設定-サービス-音声合成」で設定してください</sys:String>
     <sys:String x:Key="ImtransFailed">画像翻訳に失敗しました</sys:String>
     <sys:String x:Key="NoTranslateService">利用可能な翻訳サービスが見つかりません</sys:String>
+    <sys:String x:Key="GoToSettings">設定へ移動</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundTitle">画像翻訳サービスを取得できません</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundMessage">画像翻訳サービスが設定または有効化されていません。「設定-サービス-テキスト翻訳」で設定してからこの機能を使用してください。</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundTitle">OCRサービスを取得できません</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundMessage">OCRサービスが設定または有効化されていません。「設定-サービス-文字認識」で設定してからこの機能を使用してください。</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundTitle">画像翻訳 OCR サービスを取得できません</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundMessage">画像翻訳 OCR サービスが設定されておらず、利用可能な OCR サービスもありません。「設定-サービス-文字認識」で設定してください。</sys:String>
     <sys:String x:Key="NavigateFailed">これ以上ありません</sys:String>
     <sys:String x:Key="NoValidPluginFile">SPKGファイルがありません</sys:String>
 

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -726,6 +726,13 @@
     <sys:String x:Key="TtsServiceNotFound">음성 합성 서비스가 구성되지 않았습니다. "설정-서비스-TTS"에서 구성하세요</sys:String>
     <sys:String x:Key="ImtransFailed">이미지 번역 실패</sys:String>
     <sys:String x:Key="NoTranslateService">사용 가능한 번역 서비스를 찾을 수 없습니다</sys:String>
+    <sys:String x:Key="GoToSettings">설정으로 이동</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundTitle">이미지 번역 서비스를 가져올 수 없습니다</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundMessage">이미지 번역 서비스가 설정되어 있지 않거나 활성화되어 있지 않습니다. 이 기능을 사용하기 전에 「설정-서비스-텍스트 번역」에서 설정해 주세요.</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundTitle">OCR 서비스를 가져올 수 없습니다</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundMessage">OCR 서비스가 설정되어 있지 않거나 활성화되어 있지 않습니다. 이 기능을 사용하기 전에 「설정-서비스-텍스트 인식」에서 설정해 주세요.</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundTitle">이미지 번역 OCR 서비스를 가져올 수 없습니다</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundMessage">이미지 번역 OCR 서비스가 설정되어 있지 않고 사용 가능한 OCR 서비스도 없습니다. 「설정-서비스-텍스트 인식」에서 설정해 주세요.</sys:String>
     <sys:String x:Key="NavigateFailed">더 이상 없습니다</sys:String>
     <sys:String x:Key="NoValidPluginFile">SPKG 파일 없음</sys:String>
 

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -747,6 +747,13 @@
     <sys:String x:Key="TtsServiceNotFound">未配置语音合成服务，请前往「设置-服务-语音合成」配置</sys:String>
     <sys:String x:Key="ImtransFailed">图片翻译失败</sys:String>
     <sys:String x:Key="NoTranslateService">未找到可用的翻译服务</sys:String>
+    <sys:String x:Key="GoToSettings">点击前往</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundTitle">无法获取图片翻译服务</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundMessage">当前未配置启用图片翻译服务，请先前往「设置-服务-文本翻译」配置后使用该功能</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundTitle">无法获取OCR服务</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundMessage">当前未配置或者启用OCR服务，请先前往「设置-服务-文本识别」配置后使用该功能</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundTitle">无法获取图片翻译 OCR 服务</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundMessage">当前未配置图片翻译 OCR 服务且无可用 OCR 服务，请先前往「设置-服务-文本识别」进行配置</sys:String>
     <sys:String x:Key="NavigateFailed">已经到头了</sys:String>
     <sys:String x:Key="NoValidPluginFile">无SPKG文件</sys:String>
 

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -749,6 +749,13 @@
     <sys:String x:Key="TtsServiceNotFound">未配置語音合成服務，請前往「設定-服務-語音合成」配置</sys:String>
     <sys:String x:Key="ImtransFailed">圖片翻譯失敗</sys:String>
     <sys:String x:Key="NoTranslateService">未找到可用的翻譯服務</sys:String>
+    <sys:String x:Key="GoToSettings">點擊前往</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundTitle">無法取得圖片翻譯服務</sys:String>
+    <sys:String x:Key="ImageTranslateServiceNotFoundMessage">目前未配置或啟用圖片翻譯服務，請先前往「設定-服務-文字翻譯」配置後再使用此功能</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundTitle">無法取得 OCR 服務</sys:String>
+    <sys:String x:Key="OcrServiceNotFoundMessage">目前未配置或啟用 OCR 服務，請先前往「設定-服務-文字識別」配置後再使用此功能</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundTitle">無法取得圖片翻譯 OCR 服務</sys:String>
+    <sys:String x:Key="ImageTranslateOcrServiceNotFoundMessage">目前未配置圖片翻譯 OCR 服務且無可用 OCR 服務，請先前往「設定-服務-文字識別」進行配置</sys:String>
     <sys:String x:Key="NavigateFailed">已經到頂了</sys:String>
     <sys:String x:Key="NoValidPluginFile">無SPKG檔案</sys:String>
 

--- a/src/STranslate/ViewModels/MainWindowViewModel.cs
+++ b/src/STranslate/ViewModels/MainWindowViewModel.cs
@@ -864,8 +864,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         if (TranslateService.ImageTranslateService == null)
         {
             _notification.ShowWithButton(
-                 "无法获取图片翻译服务",
-                 "点击前往",
+                 _i18n.GetTranslation("ImageTranslateServiceNotFoundTitle"),
+                 _i18n.GetTranslation("GoToSettings"),
                  () =>
                  {
                      Application.Current.Dispatcher.Invoke(() =>
@@ -880,7 +880,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                                  .Navigate(nameof(TranslatePage));
                      });
                  },
-                 "当前未配置启用图片翻译服务，请先前往「设置-服务-文本翻译」配置后使用该功能");
+                 _i18n.GetTranslation("ImageTranslateServiceNotFoundMessage"));
             return;
         }
 
@@ -984,8 +984,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         if (svc == null)
         {
             _notification.ShowWithButton(
-                "无法获取OCR服务",
-                "点击前往",
+                _i18n.GetTranslation("OcrServiceNotFoundTitle"),
+                _i18n.GetTranslation("GoToSettings"),
                 () =>
                 {
                     Application.Current.Dispatcher.Invoke(() =>
@@ -1000,7 +1000,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                                 .Navigate(nameof(OcrPage));
                     });
                 },
-                "当前未配置或者启用OCR服务，请先前往「设置-服务-文本识别」配置后使用该功能");
+                _i18n.GetTranslation("OcrServiceNotFoundMessage"));
             return default;
         }
 
@@ -1013,8 +1013,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         if (svc == null)
         {
             _notification.ShowWithButton(
-                "无法获取图片翻译 OCR 服务",
-                "点击前往",
+                _i18n.GetTranslation("ImageTranslateOcrServiceNotFoundTitle"),
+                _i18n.GetTranslation("GoToSettings"),
                 () =>
                 {
                     Application.Current.Dispatcher.Invoke(() =>
@@ -1029,7 +1029,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                                 .Navigate(nameof(OcrPage));
                     });
                 },
-                "当前未配置图片翻译 OCR 服务且无可用 OCR 服务，请先前往「设置-服务-文本识别」进行配置");
+                _i18n.GetTranslation("ImageTranslateOcrServiceNotFoundMessage"));
             return default;
         }
 


### PR DESCRIPTION

This PR localizes OCR, image translation, and image translation OCR service-missing notifications.
将 OCR 服务缺失时的提示文案改为国际化资源，不再在 MainWindowViewModel 中硬编码中文。

## Changes

- Replaced hardcoded Chinese notification titles/messages with _i18n.GetTranslation(...).
将硬编码中文通知标题和正文替换为 _i18n.GetTranslation(...)
- Added localized resource keys for en, zh-cn, zh-tw, ja, and ko.
为英文、简体中文、繁体中文、日文、韩文补充对应资源 key
- Kept existing navigation behavior unchanged:
保持原有跳转逻辑不变
    - image translation service missing -> TranslatePage
    - OCR service missing -> OcrPage
    - image translation OCR service missing -> OcrPage

## 修复后
<img width="356" height="241" alt="FIXed_2026-05-30_21-42-54" src="https://github.com/user-attachments/assets/83c81965-84c7-4c39-abe0-2c93f5059321" />
