### PR TITLE
优化光标取词功能：自动发音改为可选，OCR 改为通用

### DIFF
--- a/src/STranslate/App.xaml.cs
+++ b/src/STranslate/App.xaml.cs
@@ -101,6 +101,7 @@ public partial class App : ISingleInstanceApp, INavigation, IDisposable
                     services.AddSingleton<ServiceManager>();
                     services.AddSingleton<PluginService>();
                     services.AddSingleton<TranslateService>();
+                    services.AddSingleton<CursorOcrService>();
                     services.AddSingleton<OcrService>();
                     services.AddSingleton<TtsService>();
                     services.AddSingleton<VocabularyService>();

--- a/src/STranslate/Core/HotkeySettings.cs
+++ b/src/STranslate/Core/HotkeySettings.cs
@@ -17,6 +17,8 @@ public partial class HotkeySettings : ObservableObject
 
     [ObservableProperty] public partial bool CrosswordTranslateByCtrlSameC { get; set; } = false;
 
+    [ObservableProperty] public partial bool CursorOcrAutoPlayAudio { get; set; } = false;
+
     [ObservableProperty] public partial Key IncrementalTranslateKey { get; set; } = Key.None;
 
     #region Setting Items
@@ -28,6 +30,7 @@ public partial class HotkeySettings : ObservableObject
     public GlobalHotkey ImageTranslateHotkey { get; set; } = new("Alt + Shift + X");
     public GlobalHotkey ReplaceTranslateHotkey { get; set; } = new(Constant.EmptyHotkey);
     public GlobalHotkey MouseHookTranslateHotkey { get; set; } = new(Constant.EmptyHotkey);
+    public GlobalHotkey CursorOcrTranslateHotkey { get; set; } = new("F2");
     public GlobalHotkey SilentOcrHotkey { get; set; } = new(Constant.EmptyHotkey);
     public GlobalHotkey SilentTtsHotkey { get; set; } = new(Constant.EmptyHotkey);
     public GlobalHotkey OcrHotkey { get; set; } = new("Alt + Shift + S");
@@ -74,6 +77,7 @@ public partial class HotkeySettings : ObservableObject
         CreateGlobalHotkeyData(InputTranslateHotkey.Key, "Hotkey_InputTranslate", () => InputTranslateHotkey.Key = Constant.EmptyHotkey),
         CreateGlobalHotkeyData(CrosswordTranslateHotkey.Key, "Hotkey_CrosswordTranslate", () => CrosswordTranslateHotkey.Key = Constant.EmptyHotkey),
         CreateGlobalHotkeyData(MouseHookTranslateHotkey.Key, "Hotkey_MouseHookTranslate", () => MouseHookTranslateHotkey.Key = Constant.EmptyHotkey),
+        CreateGlobalHotkeyData(CursorOcrTranslateHotkey.Key, "Hotkey_CursorOcrTranslate", () => CursorOcrTranslateHotkey.Key = Constant.EmptyHotkey),
         CreateGlobalHotkeyData(ReplaceTranslateHotkey.Key, "Hotkey_ReplaceTranslate", () => ReplaceTranslateHotkey.Key = Constant.EmptyHotkey),
         CreateGlobalHotkeyData(ScreenshotTranslateHotkey.Key, "Hotkey_ScreenshotTranslate", () => ScreenshotTranslateHotkey.Key = Constant.EmptyHotkey),
         CreateGlobalHotkeyData(ImageTranslateHotkey.Key, "Hotkey_ImageTranslate", () => ImageTranslateHotkey.Key = Constant.EmptyHotkey),
@@ -152,6 +156,10 @@ public partial class HotkeySettings : ObservableObject
                 ApplyCtrlCc();
                 Save();
             }
+            else if (e.PropertyName == nameof(CursorOcrAutoPlayAudio))
+            {
+                Save();
+            }
         };
 
         // 自动监听所有 GlobalHotkey 类型的属性
@@ -185,6 +193,7 @@ public partial class HotkeySettings : ObservableObject
             [nameof(ImageTranslateHotkey)] = "Alt + Shift + X",
             [nameof(ReplaceTranslateHotkey)] = "Alt + F",
             [nameof(MouseHookTranslateHotkey)] = "Alt + Shift + D",
+            [nameof(CursorOcrTranslateHotkey)] = "F2",
             [nameof(SilentOcrHotkey)] = "Alt + Shift + F",
             [nameof(SilentTtsHotkey)] = "Alt + Shift + G",
             [nameof(OcrHotkey)] = "Alt + Shift + S",
@@ -317,6 +326,7 @@ public partial class HotkeySettings : ObservableObject
         HandleGlobalLogic(nameof(InputTranslateHotkey));
         HandleGlobalLogic(nameof(CrosswordTranslateHotkey));
         HandleGlobalLogic(nameof(MouseHookTranslateHotkey));
+        HandleGlobalLogic(nameof(CursorOcrTranslateHotkey));
         HandleGlobalLogic(nameof(ReplaceTranslateHotkey));
         HandleGlobalLogic(nameof(ScreenshotTranslateHotkey));
         HandleGlobalLogic(nameof(ImageTranslateHotkey));
@@ -332,6 +342,7 @@ public partial class HotkeySettings : ObservableObject
         HotkeyManager.Current.Remove(InputTranslateHotkey.Key);
         HotkeyManager.Current.Remove(CrosswordTranslateHotkey.Key);
         HotkeyManager.Current.Remove(MouseHookTranslateHotkey.Key);
+        HotkeyManager.Current.Remove(CursorOcrTranslateHotkey.Key);
         HotkeyManager.Current.Remove(ReplaceTranslateHotkey.Key);
         HotkeyManager.Current.Remove(ScreenshotTranslateHotkey.Key);
         HotkeyManager.Current.Remove(ImageTranslateHotkey.Key);
@@ -356,6 +367,15 @@ public partial class HotkeySettings : ObservableObject
                 break;
             case nameof(MouseHookTranslateHotkey):
                 MouseHookTranslateHotkey.IsConflict = !HotkeyMapper.SetHotkey(MouseHookTranslateHotkey.Key, WithFullscreenCheck(() => MainWindowViewModel.ToggleMouseHookTranslateCommand.Execute(null)));
+                break;
+            case nameof(CursorOcrTranslateHotkey):
+                CursorOcrTranslateHotkey.IsConflict = !HotkeyMapper.SetHotkey(CursorOcrTranslateHotkey.Key, WithFullscreenCheck(() =>
+                {
+                    if (MainWindowViewModel.CursorOcrTranslateCommand.IsRunning)
+                        return;
+
+                    MainWindowViewModel.CursorOcrTranslateCommand.Execute(null);
+                }));
                 break;
             case nameof(ScreenshotTranslateHotkey):
                 ScreenshotTranslateHotkey.IsConflict = !HotkeyMapper.SetHotkey(ScreenshotTranslateHotkey.Key, WithFullscreenCheck(() => MainWindowViewModel.ScreenshotTranslateCommand.Execute(null)));

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -177,6 +177,11 @@
     <sys:String x:Key="CrosswordTranslateFetchFailedShowWindow">Failed to capture selected text, switched to main window display.</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslate">Mouse Hook Translate</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslateDescription">Shortcut key to enable/disable listening for mouse text selection to trigger translation.</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslate">Cursor OCR Translation</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslateDescription">Recognize text under the cursor and translate it without manual screenshot selection.</sys:String>
+    <sys:String x:Key="CursorOcrTranslateFailed">No text was recognized under the cursor.</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudio">Auto-play pronunciation after cursor lookup</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudioDescription">After a successful cursor lookup, play the word with the active text-to-speech service.</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslate">Replace Translation</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslateDescription">Shortcut key to translate the selected text and replace the original text.</sys:String>
     <sys:String x:Key="Hotkey_ScreenshotTranslate">Screenshot Translation</sys:String>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -173,6 +173,11 @@
     <sys:String x:Key="CrosswordTranslateFetchFailedShowWindow">選択テキストの取得に失敗しました。メイン画面を表示しました。</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslate">マウス選択監視</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslateDescription">マウス選択による翻訳トリガーの監視を有効/無効化するホットキー。</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslate">カーソル OCR 翻訳</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslateDescription">手動で範囲選択せず、カーソル下の文字を認識して翻訳します。</sys:String>
+    <sys:String x:Key="CursorOcrTranslateFailed">カーソル下の文字を認識できませんでした。</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudio">カーソル取詞後に自動発音</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudioDescription">カーソル取詞に成功した後、現在有効な音声合成サービスで単語を発音します。</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslate">置換翻訳</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslateDescription">選択したテキストを翻訳し、元のテキストを置換するホットキー。</sys:String>
     <sys:String x:Key="Hotkey_ScreenshotTranslate">スクショ翻訳</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -173,6 +173,11 @@
     <sys:String x:Key="CrosswordTranslateFetchFailedShowWindow">선택 텍스트를 가져오지 못했습니다. 메인 창을 표시했습니다.</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslate">마우스 감지</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslateDescription">마우스 드래그 텍스트 선택 번역 감지를 켜고 끄는 단축키입니다.</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslate">커서 OCR 번역</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslateDescription">수동 캡처 없이 커서 아래의 텍스트를 인식하여 번역합니다.</sys:String>
+    <sys:String x:Key="CursorOcrTranslateFailed">커서 아래에서 텍스트를 인식하지 못했습니다.</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudio">커서 단어 검색 후 자동 발음</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudioDescription">커서 단어 검색에 성공하면 현재 활성화된 음성 합성 서비스로 단어를 발음합니다.</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslate">치환 번역</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslateDescription">마우스로 선택한 텍스트를 번역하고 원본 텍스트를 치환하는 단축키입니다.</sys:String>
     <sys:String x:Key="Hotkey_ScreenshotTranslate">스크린샷 번역</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -177,6 +177,11 @@
     <sys:String x:Key="CrosswordTranslateFetchFailedShowWindow">划词取词失败，已打开主界面显示</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslate">监听鼠标划词</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslateDescription">开启/关闭监听鼠标划词选中文本触发翻译的快捷键。</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslate">光标取词翻译</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslateDescription">自动识别光标下方的文字并调用文本翻译服务，无需手动截图。</sys:String>
+    <sys:String x:Key="CursorOcrTranslateFailed">没有识别到光标下方的文字</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudio">光标取词后自动发音</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudioDescription">仅在光标取词成功后，使用当前启用的语音合成服务播放单词发音。</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslate">替换翻译</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslateDescription">鼠标选中文本触发翻译并替换原文本的快捷键。</sys:String>
     <sys:String x:Key="Hotkey_ScreenshotTranslate">截图翻译</sys:String>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -177,6 +177,11 @@
     <sys:String x:Key="CrosswordTranslateFetchFailedShowWindow">劃詞取詞失敗，已開啟主介面顯示</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslate">監聽滑鼠劃詞</sys:String>
     <sys:String x:Key="Hotkey_MouseHookTranslateDescription">開啟/關閉監聽滑鼠劃詞選中文字觸發翻譯的快速鍵。</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslate">游標取詞翻譯</sys:String>
+    <sys:String x:Key="Hotkey_CursorOcrTranslateDescription">自動辨識游標下方的文字並呼叫文字翻譯服務，無需手動截圖。</sys:String>
+    <sys:String x:Key="CursorOcrTranslateFailed">沒有辨識到游標下方的文字</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudio">游標取詞後自動發音</sys:String>
+    <sys:String x:Key="CursorOcrAutoPlayAudioDescription">僅在游標取詞成功後，使用目前啟用的語音合成服務播放單字發音。</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslate">替換翻譯</sys:String>
     <sys:String x:Key="Hotkey_ReplaceTranslateDescription">滑鼠選中文本後觸發翻譯並替換原文本的快捷鍵。</sys:String>
     <sys:String x:Key="Hotkey_ScreenshotTranslate">截圖翻譯</sys:String>

--- a/src/STranslate/Services/CursorOcrService.cs
+++ b/src/STranslate/Services/CursorOcrService.cs
@@ -1,0 +1,188 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using STranslate.Core;
+using STranslate.Plugin;
+
+namespace STranslate.Services;
+
+/// <summary>
+/// 使用 STranslate 当前启用的 OCR 服务识别光标下的英文单词。
+/// 截图保持原始尺寸和颜色，便于对比不同 OCR 服务的原生效果。
+/// </summary>
+public sealed class CursorOcrService
+{
+    private const int CaptureWidth = 480;
+    private const int CaptureHeight = 72;
+    private const int FallbackCaptureWidth = 840;
+    private const int FallbackCaptureHeight = 104;
+    private const int SmXVirtualScreen = 76;
+    private const int SmYVirtualScreen = 77;
+    private const int SmCxVirtualScreen = 78;
+    private const int SmCyVirtualScreen = 79;
+
+    private readonly OcrService _ocrService;
+    private readonly SemaphoreSlim _recognizeLock = new(1, 1);
+
+    public CursorOcrService(OcrService ocrService) => _ocrService = ocrService;
+
+    public async Task<CursorOcrResult> RecognizeWordUnderCursorAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _recognizeLock.WaitAsync(cancellationToken);
+        try
+        {
+            var plugin = _ocrService.GetActiveSvc<IOcrPlugin>();
+            if (plugin == null)
+                return CursorOcrResult.Fail("未找到已启用的 OCR 服务");
+
+            var selected = await RecognizePassAsync(plugin, CaptureWidth, CaptureHeight, cancellationToken);
+            if (selected == null || selected.TouchesHorizontalEdge)
+            {
+                var fallback = await RecognizePassAsync(
+                    plugin, FallbackCaptureWidth, FallbackCaptureHeight, cancellationToken);
+                selected = fallback ?? selected;
+            }
+
+            if (selected == null || string.IsNullOrWhiteSpace(selected.Text))
+                return CursorOcrResult.Fail("没有识别到光标下方的文字");
+
+            return IsEnglishWord(selected.Text)
+                ? CursorOcrResult.Success(selected.Text)
+                : CursorOcrResult.Fail("光标取词仅支持英文单词");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return CursorOcrResult.Fail(ex.Message);
+        }
+        finally
+        {
+            _recognizeLock.Release();
+        }
+    }
+
+    private static async Task<SelectedWord?> RecognizePassAsync(
+        IOcrPlugin plugin, int width, int height, CancellationToken cancellationToken)
+    {
+        using var captured = CaptureAroundCursor(width, height);
+        using var stream = new MemoryStream();
+        captured.Bitmap.Save(stream, ImageFormat.Png);
+
+        var result = await plugin.RecognizeAsync(
+            new OcrRequest(stream.ToArray(), LangEnum.English, captured.Bitmap.Width, captured.Bitmap.Height),
+            cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!result.IsSuccess)
+            return null;
+
+        // 与主程序其它 OCR 入口保持一致：将仅返回 Regions 的插件结果投影为 OcrContents。
+        Utilities.PrepareOcrResult(result);
+
+        var contents = result.OcrContents
+            .Where(content => !string.IsNullOrWhiteSpace(content.Text))
+            .Select(content => new OcrItem(content.Text.Trim(), GetBounds(content.BoxPoints)))
+            .Where(item => item.Bounds.HasValue)
+            .ToList();
+
+        if (contents.Count == 0)
+            return null;
+
+        var cursorX = captured.CursorX;
+        var cursorY = captured.CursorY;
+        var match = contents
+            .Select(item => new
+            {
+                item.Text,
+                Bounds = item.Bounds!.Value,
+                Exact = item.Bounds.Value.Contains((float)cursorX, (float)cursorY)
+            })
+            .OrderByDescending(item => item.Exact)
+            .ThenBy(item => DistanceToCenter(item.Bounds, cursorX, cursorY))
+            .FirstOrDefault();
+
+        if (match == null)
+            return null;
+
+        var text = ExtractTokenAtCursor(match.Text, match.Bounds.X, match.Bounds.Width, cursorX);
+        return string.IsNullOrWhiteSpace(text)
+            ? null
+            : new SelectedWord(text, match.Bounds.Left <= 4 || match.Bounds.Right >= width - 4);
+    }
+
+    private static CapturedRegion CaptureAroundCursor(int width, int height)
+    {
+        if (!GetCursorPos(out var cursor))
+            throw new InvalidOperationException("无法获取鼠标位置");
+
+        var leftBound = GetSystemMetrics(SmXVirtualScreen);
+        var topBound = GetSystemMetrics(SmYVirtualScreen);
+        var screenWidth = GetSystemMetrics(SmCxVirtualScreen);
+        var screenHeight = GetSystemMetrics(SmCyVirtualScreen);
+        var left = Math.Clamp(cursor.X - width / 2, leftBound, Math.Max(leftBound, leftBound + screenWidth - width));
+        var top = Math.Clamp(cursor.Y - height / 2, topBound, Math.Max(topBound, topBound + screenHeight - height));
+
+        var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.CopyFromScreen(left, top, 0, 0, new Size(width, height), CopyPixelOperation.SourceCopy);
+        return new CapturedRegion(bitmap, cursor.X - left, cursor.Y - top);
+    }
+
+    private static RectangleF? GetBounds(List<BoxPoint> points)
+    {
+        if (points == null || points.Count == 0)
+            return null;
+        var left = points.Min(point => point.X);
+        var top = points.Min(point => point.Y);
+        var right = points.Max(point => point.X);
+        var bottom = points.Max(point => point.Y);
+        return right > left && bottom > top ? new RectangleF(left, top, right - left, bottom - top) : null;
+    }
+
+    private static double DistanceToCenter(RectangleF bounds, double x, double y)
+        => Math.Pow(bounds.X + bounds.Width / 2 - x, 2) + Math.Pow(bounds.Y + bounds.Height / 2 - y, 2);
+
+    private static string ExtractTokenAtCursor(string text, double wordX, double wordWidth, double cursorX)
+    {
+        var value = text.Trim();
+        var tokens = System.Text.RegularExpressions.Regex.Matches(value, @"[A-Za-z]+(?:['-][A-Za-z]+)*")
+            .Select(match => (Start: match.Index, End: match.Index + match.Length)).ToList();
+        if (tokens.Count == 0) return string.Empty;
+        var index = Math.Clamp((cursorX - wordX) / Math.Max(1, wordWidth) * value.Length, 0, value.Length - 1);
+        var token = tokens.OrderBy(range => index < range.Start ? range.Start - index : index >= range.End ? index - range.End : 0).First();
+        return value[token.Start..token.End];
+    }
+
+    private static bool IsEnglishWord(string text) =>
+        !string.IsNullOrWhiteSpace(text) && System.Text.RegularExpressions.Regex.IsMatch(text, @"^[A-Za-z]+(?:['-][A-Za-z]+)*$");
+
+    private sealed record OcrItem(string Text, RectangleF? Bounds);
+    private sealed record SelectedWord(string Text, bool TouchesHorizontalEdge);
+    private sealed class CapturedRegion(Bitmap bitmap, double cursorX, double cursorY) : IDisposable
+    {
+        public Bitmap Bitmap { get; } = bitmap;
+        public double CursorX { get; } = cursorX;
+        public double CursorY { get; } = cursorY;
+        public void Dispose() => Bitmap.Dispose();
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out NativePoint point);
+    [DllImport("user32.dll")] private static extern int GetSystemMetrics(int index);
+    [StructLayout(LayoutKind.Sequential)] private struct NativePoint { public int X; public int Y; }
+}
+
+public sealed class CursorOcrResult
+{
+    public string Text { get; private init; } = string.Empty;
+    public bool IsSuccess { get; private init; }
+    public string ErrorMessage { get; private init; } = string.Empty;
+    public static CursorOcrResult Success(string text) => new() { Text = text, IsSuccess = true };
+    public static CursorOcrResult Fail(string message) => new() { ErrorMessage = message, IsSuccess = false };
+}

--- a/src/STranslate/ViewModels/MainWindowViewModel.cs
+++ b/src/STranslate/ViewModels/MainWindowViewModel.cs
@@ -33,9 +33,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private readonly IScreenshot _screenshot;
     private readonly ISnackbar _snackbar;
     private readonly INotification _notification;
+    private readonly CursorOcrService _cursorOcrService;
     private double _cacheLeft;
     private double _cacheTop;
     private bool _isAdjustingWindowPositionForContent;
+    private bool _avoidCursorForNextShow;
 
     public TranslateService TranslateService { get; }
     public OcrService OcrService { get; }
@@ -64,6 +66,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IScreenshot screenshot,
         ISnackbar snackbar,
         INotification notification,
+        CursorOcrService cursorOcrService,
         TranslateService translateService,
         OcrService ocrService,
         TtsService ttsService,
@@ -83,6 +86,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _screenshot = screenshot;
         _snackbar = snackbar;
         _notification = notification;
+        _cursorOcrService = cursorOcrService;
         TranslateService = translateService;
         OcrService = ocrService;
         TtsService = ttsService;
@@ -1174,6 +1178,25 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         });
     }
 
+    [RelayCommand(IncludeCancelCommand = true)]
+    private async Task CursorOcrTranslateAsync(CancellationToken cancellationToken)
+    {
+        var result = await _cursorOcrService.RecognizeWordUnderCursorAsync(cancellationToken);
+        if (!result.IsSuccess || string.IsNullOrWhiteSpace(result.Text))
+        {
+            Show();
+            _snackbar.ShowWarning(string.IsNullOrWhiteSpace(result.ErrorMessage)
+                ? _i18n.GetTranslation("CursorOcrTranslateFailed")
+                : result.ErrorMessage);
+            return;
+        }
+
+        _avoidCursorForNextShow = true;
+        ExecuteTranslate(result.Text);
+        if (HotkeySettings.CursorOcrAutoPlayAudio)
+            await PlayAudioAsync(result.Text, cancellationToken);
+    }
+
     public async Task OcrHandlerAsync(Bitmap? bitmap)
     {
         if (bitmap == null) return;
@@ -1757,6 +1780,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public void Show()
     {
+        var avoidCursor = _avoidCursorForNextShow;
+        _avoidCursorForNextShow = false;
+
         if (Settings.MainWindowLeft <= -18000 && Settings.MainWindowTop <= -18000)
         {
             Settings.MainWindowLeft = _cacheLeft;
@@ -1764,8 +1790,13 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
         MainWindow.Visibility = Visibility.Visible;
         UpdateMainWindowMaxHeightConstraint();
-        UpdatePosition();
-        UpdateMainWindowMaxHeightConstraint();
+        if (avoidCursor)
+            UpdatePositionAwayFromCapturedWord();
+        else
+        {
+            UpdatePosition();
+            UpdateMainWindowMaxHeightConstraint();
+        }
 
         Win32Helper.ActivateForegroundWindow(MainWindow);
 
@@ -2212,6 +2243,54 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         Settings.MainWindowLeft = Math.Clamp(left, minLeft, maxLeft);
         Settings.MainWindowTop = Math.Clamp(top, minTop, maxTop);
+    }
+
+    private void UpdatePositionAwayFromCapturedWord()
+    {
+        if (!PInvoke.GetCursorPos(out var cursorPosition))
+        {
+            UpdatePosition();
+            return;
+        }
+
+        const double wordGap = 44;
+        const double edgePadding = 8;
+
+        var cursorDip = Win32Helper.TransformPixelsToDIP(MainWindow, cursorPosition.X, cursorPosition.Y);
+        var screen = MonitorInfo.GetCursorDisplayMonitor();
+        UpdateMainWindowMaxHeightConstraint(screen);
+
+        var workAreaTopLeft = Win32Helper.TransformPixelsToDIP(MainWindow, screen.WorkingArea.X, screen.WorkingArea.Y);
+        var workAreaBottomRight = Win32Helper.TransformPixelsToDIP(
+            MainWindow,
+            screen.WorkingArea.X + screen.WorkingArea.Width,
+            screen.WorkingArea.Y + screen.WorkingArea.Height);
+
+        var windowWidth = MainWindow.ActualWidth > 0 ? MainWindow.ActualWidth : Settings.MainWindowWidth;
+        var minLeft = workAreaTopLeft.X + edgePadding;
+        var minTop = workAreaTopLeft.Y + edgePadding;
+        var maxLeft = Math.Max(minLeft, workAreaBottomRight.X - windowWidth - edgePadding);
+
+        var availableBelow = Math.Max(0, workAreaBottomRight.Y - edgePadding - cursorDip.Y - wordGap);
+        var availableAbove = Math.Max(0, cursorDip.Y - wordGap - minTop);
+        var placeBelow = availableBelow >= availableAbove;
+        var availableHeight = placeBelow ? availableBelow : availableAbove;
+
+        MainWindowEffectiveMaxHeight = Math.Max(MainWindow.MinHeight, availableHeight);
+        MainWindow.UpdateLayout();
+
+        var windowHeight = Math.Min(
+            MainWindow.ActualHeight > 0 ? MainWindow.ActualHeight : MainWindow.MinHeight,
+            MainWindowEffectiveMaxHeight);
+        var left = cursorDip.X <= (workAreaTopLeft.X + workAreaBottomRight.X) / 2
+            ? maxLeft
+            : minLeft;
+        var top = placeBelow
+            ? cursorDip.Y + wordGap
+            : cursorDip.Y - wordGap - windowHeight;
+
+        Settings.MainWindowLeft = Math.Clamp(left, minLeft, maxLeft);
+        Settings.MainWindowTop = Math.Clamp(top, minTop, Math.Max(minTop, workAreaBottomRight.Y - windowHeight - edgePadding));
     }
 
     /// <summary>

--- a/src/STranslate/Views/Pages/HotkeyPage.xaml
+++ b/src/STranslate/Views/Pages/HotkeyPage.xaml
@@ -188,6 +188,29 @@
                             WindowTitle="{DynamicResource Hotkey_MouseHookTranslate}" />
                     </ui:SettingsCard>
 
+                    <ui:SettingsCard Description="{DynamicResource Hotkey_CursorOcrTranslateDescription}" Header="{DynamicResource Hotkey_CursorOcrTranslate}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Icon="{x:Static ui:FluentSystemIcons.CursorHover_20_Regular}" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <StackPanel Orientation="Horizontal">
+                            <control:HotkeyControl
+                                DefaultHotkey="{Binding HotkeySettings.CursorOcrTranslateHotkey.Default}"
+                                Hotkey="{Binding HotkeySettings.CursorOcrTranslateHotkey.Key}"
+                                IsRegistered="{Binding HotkeySettings.CursorOcrTranslateHotkey.IsConflict}"
+                                WindowTitle="{DynamicResource Hotkey_CursorOcrTranslate}" />
+                            <TextBlock
+                                Margin="16,0,8,0"
+                                VerticalAlignment="Center"
+                                Foreground="{DynamicResource {x:Static ui:ThemeKeys.TextFillColorPrimaryBrushKey}}"
+                                Text="自动发音" />
+                            <ui:ToggleSwitch
+                                IsOn="{Binding HotkeySettings.CursorOcrAutoPlayAudio}"
+                                OffContent=""
+                                OnContent=""
+                                ToolTip="{DynamicResource CursorOcrAutoPlayAudioDescription}" />
+                        </StackPanel>
+                    </ui:SettingsCard>
+
                     <ui:SettingsCard Description="{DynamicResource Hotkey_SilentOcrDescription}" Header="{DynamicResource Hotkey_SilentOcr}">
                         <ui:SettingsCard.HeaderIcon>
                             <ui:FontIcon Icon="{x:Static ui:FluentSystemIcons.ScanTypeOff_24_Regular}" />


### PR DESCRIPTION
## 优化光标取词功能

### 优化识别过程

原来：  
截图 → 放大、灰度、对比度、锐化 → Windows 自带 OCR → 取词 → 翻译

优化后：  
截图原图 → 当前启用的 STranslate OCR 插件 → 根据文字坐标取词 → 翻译

### 自动发音

- 光标取词自动发音改为可选开关，默认关闭。
- 开启后，仅在光标取词成功时播放发音，不影响其他翻译功能。