### PR TITLE
fix: RTL text rendering in the translation input and output

### DIFF
--- a/src/STranslate/Controls/HistoryControl.xaml
+++ b/src/STranslate/Controls/HistoryControl.xaml
@@ -28,7 +28,13 @@
                         IsReadOnly="True"
                         SnapsToDevicePixels="True"
                         Text="{Binding TransResult.Text}"
-                        TextWrapping="Wrap" />
+                        TextWrapping="Wrap">
+                        <TextBox.FlowDirection>
+                            <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                <Binding Path="TransResult.Text" />
+                            </MultiBinding>
+                        </TextBox.FlowDirection>
+                    </TextBox>
                     <Grid
                         Grid.Row="1"
                         Margin="6,2"
@@ -73,7 +79,13 @@
                             BorderThickness="0"
                             IsReadOnly="True"
                             Text="{Binding TransBackResult.Text}"
-                            TextWrapping="Wrap" />
+                            TextWrapping="Wrap">
+                            <TextBox.FlowDirection>
+                                <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                    <Binding Path="TransBackResult.Text" />
+                                </MultiBinding>
+                            </TextBox.FlowDirection>
+                        </TextBox>
                         <ikw:SimpleStackPanel
                             Grid.Row="1"
                             Margin="6,2"
@@ -111,7 +123,13 @@
                         IsReadOnly="True"
                         Style="{DynamicResource TextBlockSimilarStyle}"
                         Text="{Binding DictResult.Text}"
-                        TextWrapping="Wrap" />
+                        TextWrapping="Wrap">
+                        <TextBox.FlowDirection>
+                            <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                <Binding Path="DictResult.Text" />
+                            </MultiBinding>
+                        </TextBox.FlowDirection>
+                    </TextBox>
                     <!--  音标显示  -->
                     <ItemsControl
                         Margin="0,0,0,4"
@@ -178,7 +196,13 @@
                                         FontWeight="Medium"
                                         Foreground="{DynamicResource {x:Static ui:ThemeKeys.AccentTextFillColorPrimaryBrushKey}}"
                                         Text="{Binding PartOfSpeech}"
-                                        Visibility="{Binding PartOfSpeech, Converter={cnvt:EqualToVisibilityInverseConverter}}" />
+                                        Visibility="{Binding PartOfSpeech, Converter={cnvt:EqualToVisibilityInverseConverter}}">
+                                        <TextBlock.FlowDirection>
+                                            <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                                <Binding Path="PartOfSpeech" />
+                                            </MultiBinding>
+                                        </TextBlock.FlowDirection>
+                                    </TextBlock>
                                     <!--  释义  -->
                                     <TextBox
                                         Grid.Column="1"
@@ -186,7 +210,13 @@
                                         IsReadOnly="True"
                                         Style="{DynamicResource TextBlockSimilarStyle}"
                                         Text="{Binding Means, Converter={cnvt:CollectionToStringConverter}, ConverterParameter=；}"
-                                        TextWrapping="Wrap" />
+                                        TextWrapping="Wrap">
+                                        <TextBox.FlowDirection>
+                                            <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                                <Binding Path="Means" Converter="{cnvt:CollectionToStringConverter}" ConverterParameter="；" />
+                                            </MultiBinding>
+                                        </TextBox.FlowDirection>
+                                    </TextBox>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -253,7 +283,13 @@
                                     <TextBlock
                                         FontStyle="Italic"
                                         Text="{Binding}"
-                                        TextWrapping="Wrap" />
+                                        TextWrapping="Wrap">
+                                        <TextBlock.FlowDirection>
+                                            <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                                <Binding />
+                                            </MultiBinding>
+                                        </TextBlock.FlowDirection>
+                                    </TextBlock>
                                 </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -353,7 +389,13 @@
                                             IsReadOnly="True"
                                             SnapsToDevicePixels="True"
                                             Text="{Binding SourceText, Mode=OneWay}"
-                                            TextWrapping="Wrap" />
+                                            TextWrapping="Wrap">
+                                            <TextBox.FlowDirection>
+                                                <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                                    <Binding Path="SourceText" />
+                                                </MultiBinding>
+                                            </TextBox.FlowDirection>
+                                        </TextBox>
                                         <ikw:SimpleStackPanel
                                             Grid.Row="1"
                                             Margin="6,2"

--- a/src/STranslate/Controls/InputControl.cs
+++ b/src/STranslate/Controls/InputControl.cs
@@ -56,6 +56,19 @@ public class InputControl : Control
                 string.Empty,
                 FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
 
+    public LangEnum SourceLanguage
+    {
+        get => (LangEnum)GetValue(SourceLanguageProperty);
+        set => SetValue(SourceLanguageProperty, value);
+    }
+
+    public static readonly DependencyProperty SourceLanguageProperty =
+        DependencyProperty.Register(
+            nameof(SourceLanguage),
+            typeof(LangEnum),
+            typeof(InputControl),
+            new PropertyMetadata(LangEnum.Auto));
+
     public IdentifiedLanguageStateKind IdentifiedLanguageState
     {
         get => (IdentifiedLanguageStateKind)GetValue(IdentifiedLanguageStateProperty);

--- a/src/STranslate/Controls/InputControl.xaml
+++ b/src/STranslate/Controls/InputControl.xaml
@@ -143,6 +143,13 @@
                                 BorderThickness="0"
                                 Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text, UpdateSourceTrigger=PropertyChanged}"
                                 TextWrapping="Wrap">
+                                <TextBox.FlowDirection>
+                                    <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                        <Binding RelativeSource="{RelativeSource Mode=TemplatedParent}" Path="Text" />
+                                        <Binding RelativeSource="{RelativeSource Mode=TemplatedParent}" Path="SourceLanguage" />
+                                        <Binding RelativeSource="{RelativeSource Mode=TemplatedParent}" Path="SelectedIdentifiedLanguage" />
+                                    </MultiBinding>
+                                </TextBox.FlowDirection>
                                 <TextBox.InputBindings>
                                     <KeyBinding Key="Enter" Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ExecuteCommand}" />
                                     <KeyBinding

--- a/src/STranslate/Controls/OutputControl.cs
+++ b/src/STranslate/Controls/OutputControl.cs
@@ -1,3 +1,4 @@
+using STranslate.Plugin;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -132,6 +133,19 @@ public class OutputControl : ItemsControl
             typeof(bool),
             typeof(OutputControl),
             new PropertyMetadata(true));
+
+    public LangEnum TargetLanguage
+    {
+        get => (LangEnum)GetValue(TargetLanguageProperty);
+        set => SetValue(TargetLanguageProperty, value);
+    }
+
+    public static readonly DependencyProperty TargetLanguageProperty =
+        DependencyProperty.Register(
+            nameof(TargetLanguage),
+            typeof(LangEnum),
+            typeof(OutputControl),
+            new PropertyMetadata(LangEnum.Auto));
 
     public ICommand? ExplainCommand
     {

--- a/src/STranslate/Controls/OutputControl.xaml
+++ b/src/STranslate/Controls/OutputControl.xaml
@@ -235,7 +235,14 @@
                             IsReadOnly="True"
                             Text="{Binding Plugin.DictionaryResult.Text}"
                             TextWrapping="Wrap"
-                            Visibility="{Binding Plugin.DictionaryResult.ResultType, Converter={cnvt:DictionaryResultTypeVisibilityConverter}, ConverterParameter=Error}" />
+                            Visibility="{Binding Plugin.DictionaryResult.ResultType, Converter={cnvt:DictionaryResultTypeVisibilityConverter}, ConverterParameter=Error}">
+                            <TextBox.FlowDirection>
+                                <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                    <Binding Path="Plugin.DictionaryResult.Text" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=control:OutputControl}" Path="TargetLanguage" />
+                                </MultiBinding>
+                            </TextBox.FlowDirection>
+                        </TextBox>
                         <StackPanel Margin="8,8,8,4" Visibility="{Binding Plugin.DictionaryResult.ResultType, Converter={cnvt:DictionaryResultTypeVisibilityConverter}, ConverterParameter=Success}">
                             <!--  单词显示  -->
                             <TextBox
@@ -246,7 +253,14 @@
                                 IsReadOnly="True"
                                 Style="{DynamicResource TextBlockSimilarStyle}"
                                 Text="{Binding Plugin.DictionaryResult.Text}"
-                                TextWrapping="Wrap" />
+                                TextWrapping="Wrap">
+                                <TextBox.FlowDirection>
+                                    <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                        <Binding Path="Plugin.DictionaryResult.Text" />
+                                        <Binding RelativeSource="{RelativeSource AncestorType=control:OutputControl}" Path="TargetLanguage" />
+                                    </MultiBinding>
+                                </TextBox.FlowDirection>
+                            </TextBox>
 
                             <!--  音标显示  -->
                             <ItemsControl
@@ -632,6 +646,12 @@
                                 SnapsToDevicePixels="True"
                                 Text="{Binding Plugin.TransResult.Text}"
                                 TextWrapping="Wrap">
+                                <TextBox.FlowDirection>
+                                    <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                        <Binding Path="Plugin.TransResult.Text" />
+                                        <Binding RelativeSource="{RelativeSource AncestorType=control:OutputControl}" Path="TargetLanguage" />
+                                    </MultiBinding>
+                                </TextBox.FlowDirection>
                                 <TextBox.Style>
                                     <Style BasedOn="{StaticResource {x:Type TextBox}}" TargetType="TextBox">
                                         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
@@ -752,6 +772,12 @@
                                     IsReadOnly="True"
                                     Text="{Binding Plugin.TransBackResult.Text}"
                                     TextWrapping="Wrap">
+                                    <TextBox.FlowDirection>
+                                        <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                            <Binding Path="Plugin.TransBackResult.Text" />
+                                            <Binding RelativeSource="{RelativeSource AncestorType=control:OutputControl}" Path="TargetLanguage" />
+                                        </MultiBinding>
+                                    </TextBox.FlowDirection>
                                     <TextBox.Style>
                                         <Style BasedOn="{StaticResource {x:Type TextBox}}" TargetType="TextBox">
                                             <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />

--- a/src/STranslate/Converters/TextAndLanguageToFlowDirectionConverter.cs
+++ b/src/STranslate/Converters/TextAndLanguageToFlowDirectionConverter.cs
@@ -1,0 +1,28 @@
+using STranslate.Helpers;
+using STranslate.Plugin;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace STranslate.Converters;
+
+public class TextAndLanguageToFlowDirectionConverter : MarkupExtension, IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 0)
+            return FlowDirection.LeftToRight;
+
+        var text = values[0] as string;
+        var language = values.Length > 1 && values[1] is LangEnum lang ? lang : LangEnum.Auto;
+        var detectedLanguage = values.Length > 2 && values[2] is LangEnum identified ? identified : LangEnum.Auto;
+
+        return BidiDirectionHelper.GetFlowDirection(text, language, detectedLanguage);
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => [Binding.DoNothing];
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+}

--- a/src/STranslate/Helpers/BidiDirectionHelper.cs
+++ b/src/STranslate/Helpers/BidiDirectionHelper.cs
@@ -1,0 +1,114 @@
+using STranslate.Plugin;
+using System.Windows;
+using System.Globalization;
+using System.Text;
+
+namespace STranslate.Helpers;
+
+public static class BidiDirectionHelper
+{
+    private static readonly LangEnum[] RtlLanguages =
+    [
+        LangEnum.Arabic,
+        LangEnum.Persian,
+//        TODO uncomment these when you add other languages to the app
+//        LangEnum.Hebrew,
+//        LangEnum.Urdu,
+//        LangEnum.Pashto,
+//        LangEnum.Sindhi,
+//        LangEnum.Kurdish,
+//        LangEnum.Yiddish
+    ];
+
+    public static FlowDirection GetFlowDirection(
+        string? text,
+        LangEnum? language = null,
+        LangEnum? detectedLanguage = null)
+    {
+        if (TryGetLanguageDirection(language, out var direction))
+            return direction;
+
+        if (TryGetLanguageDirection(detectedLanguage, out direction))
+            return direction;
+
+        return GetDirectionFromText(text);
+    }
+
+    private static bool TryGetLanguageDirection(
+        LangEnum? language,
+        out FlowDirection direction)
+    {
+        direction = FlowDirection.LeftToRight;
+
+        if (language is null or LangEnum.Auto)
+            return false;
+
+        direction = IsRightToLeftLanguage(language.Value)
+            ? FlowDirection.RightToLeft
+            : FlowDirection.LeftToRight;
+
+        return true;
+    }
+
+    private static FlowDirection GetDirectionFromText(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return FlowDirection.LeftToRight;
+
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (IsRightToLeftRune(rune))
+                return FlowDirection.RightToLeft;
+
+            if (IsLeftToRightRune(rune))
+                return FlowDirection.LeftToRight;
+        }
+
+        return FlowDirection.LeftToRight;
+    }
+
+    private static bool IsRightToLeftLanguage(LangEnum language)
+        => RtlLanguages.Contains(language);
+
+    private static bool IsRightToLeftRune(Rune rune)
+    {
+        var value = rune.Value;
+
+        return
+            // Hebrew
+            value is >= 0x0590 and <= 0x05FF ||
+
+            // Arabic
+            value is >= 0x0600 and <= 0x06FF ||
+
+            // Arabic Supplement
+            value is >= 0x0750 and <= 0x077F ||
+
+            // Arabic Extended-A
+            value is >= 0x08A0 and <= 0x08FF ||
+
+            // Hebrew Presentation Forms
+            value is >= 0xFB1D and <= 0xFB4F ||
+
+            // Arabic Presentation Forms-A
+            value is >= 0xFB50 and <= 0xFDFF ||
+
+            // Arabic Presentation Forms-B
+            value is >= 0xFE70 and <= 0xFEFF ||
+
+            // Arabic Mathematical Alphabetic Symbols
+            value is >= 0x1EE00 and <= 0x1EEFF;
+    }
+
+    private static bool IsLeftToRightRune(Rune rune)
+    {
+        var category = Rune.GetUnicodeCategory(rune);
+
+        return category is
+            UnicodeCategory.UppercaseLetter or
+            UnicodeCategory.LowercaseLetter or
+            UnicodeCategory.TitlecaseLetter or
+            UnicodeCategory.ModifierLetter or
+            UnicodeCategory.OtherLetter;
+    }
+}

--- a/src/STranslate/Views/MainWindow.xaml
+++ b/src/STranslate/Views/MainWindow.xaml
@@ -151,6 +151,7 @@
                     SelectLanguageDetectorCommand="{Binding SelectLanguageDetectorCommand}"
                     SelectedIdentifiedLanguage="{Binding SelectedIdentifiedLanguage}"
                     SelectedLanguageDetector="{Binding Settings.LanguageDetector, Mode=TwoWay}"
+                    SourceLanguage="{Binding Settings.SourceLang}"
                     Text="{Binding InputText, UpdateSourceTrigger=PropertyChanged}"
                     TranslateOnPaste="{Binding Settings.TranslateOnPaste}"
                     Visibility="{Binding IsInputBoxVisible, Converter={cnvt:BoolToVisibilityConverter}}" />
@@ -281,6 +282,7 @@
                     ShowPascalCase="{Binding Settings.ShowPascalCase}"
                     ShowPrompt="{Binding Settings.ShowPromptButton}"
                     ShowSnakeCase="{Binding Settings.ShowSnakeCase}"
+                    TargetLanguage="{Binding Settings.TargetLang}"
                     TransBackCommand="{Binding SingleTransBackCommand}" />
             </StackPanel>
         </ui:ScrollViewerEx>

--- a/src/STranslate/Views/Pages/HistoryPage.xaml
+++ b/src/STranslate/Views/Pages/HistoryPage.xaml
@@ -133,7 +133,13 @@
                                 VerticalAlignment="Center"
                                 Text="{Binding SourceText}"
                                 TextTrimming="CharacterEllipsis"
-                                TextWrapping="NoWrap" />
+                                TextWrapping="NoWrap">
+                                <TextBlock.FlowDirection>
+                                    <MultiBinding Converter="{cnvt:TextAndLanguageToFlowDirectionConverter}">
+                                        <Binding Path="SourceText" />
+                                    </MultiBinding>
+                                </TextBlock.FlowDirection>
+                            </TextBlock>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>


### PR DESCRIPTION
# Fix RTL text ordering

RTL translations that contain a mix of RTL and LTR text can be displayed in the wrong order. This PR detects the correct text direction and applies it to the input control.

### Issue

When an RTL translation contains LTR content such as English words, URLs, or numbers, the text can be displayed in the wrong order.

<img width="483" height="80" alt="image" src="https://github.com/user-attachments/assets/2fd92180-5661-4df0-bda4-c4a1fc5ad81b" />


### Fix

Automatically detect whether the text should use RTL or LTR direction based on the language and text content.

For example, Persian or Arabic text containing English words, URLs, or numbers will now keep the expected ordering.
<img width="512" height="108" alt="image" src="https://github.com/user-attachments/assets/94036b1d-cb56-4e10-87ac-17109264b76a" />


This is the actual text in case you want to test it. GitHub doesn't render it properly either, so you can copy it to Telegram or another app with proper RTL support.

```
سلام، کد «ABC» است.
```