### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ Copyright © [zggsong](https://github.com/zggsong)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ZGGSONG/STranslate&type=Date)](https://star-history.com/#ZGGSONG/STranslate&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ZGGSONG/STranslate&type=Date)](https://star-history.dera.page/#ZGGSONG/STranslate&Date)
 

--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ Copyright © [zggsong](https://github.com/zggsong)
 
 ## Star History
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=ZGGSONG/STranslate&type=Date)](https://star-history.dera.page/#ZGGSONG/STranslate&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=STranslate/STranslate&type=Date)](https://star-history.dera.page/#STranslate/STranslate&Date)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -89,4 +89,4 @@
 
 ## 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ZGGSONG/STranslate&type=Date)](https://star-history.com/#ZGGSONG/STranslate&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ZGGSONG/STranslate&type=Date)](https://star-history.dera.page/#ZGGSONG/STranslate&Date)


### PR DESCRIPTION
The star history chart is currently broken because of GitHub stargazer API restrictions. Update the chart image and link so it renders correctly again.