### PR TITLE
feat: pin static image translation results from Compact

### DIFF
--- a/src/STranslate/App.xaml.cs
+++ b/src/STranslate/App.xaml.cs
@@ -35,6 +35,7 @@ public partial class App : ISingleInstanceApp, INavigation, IDisposable
     private MainWindow? _mainWindow;
     private MainWindowViewModel? _mainWindowViewModel;
     private PluginManager? _pluginManager;
+    private PinnedWindowController? _pinnedWindowController;
     private Notification? _notification;
     private AutoUpdateCheckerService? _autoUpdateCheckerService;
     private MouseSelectionService? _mouseSelectionService;
@@ -130,6 +131,7 @@ public partial class App : ISingleInstanceApp, INavigation, IDisposable
                     services.AddSingleton<IAudioPlayer, AudioPlayer>();
                     services.AddSingleton<IScreenshot, Screenshot>();
                     services.AddSingleton<ISnackbar, Snackbar>();
+                    services.AddSingleton<PinnedWindowController>();
 
                     services.AddSingleton<BackupService>();
 
@@ -209,6 +211,7 @@ public partial class App : ISingleInstanceApp, INavigation, IDisposable
         _pluginManager = Ioc.Default.GetRequiredService<PluginManager>();
         _pluginManager.LoadPlugins();
         Ioc.Default.GetRequiredService<ServiceManager>().LoadServices();
+        _pinnedWindowController = Ioc.Default.GetRequiredService<PinnedWindowController>();
         Ioc.Default.GetRequiredService<SqlService>().InitializeDB();
 
         RegisterAppDomainExceptions();
@@ -550,6 +553,7 @@ public partial class App : ISingleInstanceApp, INavigation, IDisposable
             _autoUpdateCheckerService?.Dispose();
             _hotkeySettings?.Dispose();
             _notification?.Uninstall();
+            _pinnedWindowController?.CloseAll();
             _mainWindowViewModel?.Dispose();
             _mouseSelectionService?.Dispose();
             _mainWindow?.Dispatcher.Invoke(_mainWindow.Dispose);

--- a/src/STranslate/Controls/ImageZoom.cs
+++ b/src/STranslate/Controls/ImageZoom.cs
@@ -326,6 +326,8 @@ public class ImageZoom : Control
     private static void OnOcrWordsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var control = (ImageZoom)d;
+        // 数据源切换后旧选择索引失效。
+        control.ResetSelection();
         control._fullTextCache = null; // 清除缓存
         control.UpdateSelectedText(); // 更新选中文本
     }
@@ -576,6 +578,69 @@ public class ImageZoom : Control
 
     private bool IsPointOverAnyWord(Point point) => FindWordAtPoint(point) != null;
 
+    /// <summary>
+    /// 判断 ImageZoom 坐标是否位于可选文字上。
+    /// </summary>
+    public bool IsPointOverSelectableText(Point pointRelativeToControl)
+    {
+        if (_interactionCanvas == null || OcrWords == null || OcrWords.Count == 0)
+            return false;
+
+        var pointOnCanvas = TranslatePoint(pointRelativeToControl, _interactionCanvas);
+        return IsPointOverAnyWord(pointOnCanvas);
+    }
+
+    /// <summary>
+    /// 清除当前文字选择。
+    /// </summary>
+    public void ClearTextSelection() => ResetSelection();
+
+    internal bool IsPointOverTextSelection(Point point)
+    {
+        if (_interactionCanvas == null || _selectionStartIndex == null || _selectionEndIndex == null)
+            return false;
+        var word = FindWordAtPoint(TranslatePoint(point, _interactionCanvas));
+        return word != null && IsWordInSelection(word,
+            Math.Min(_selectionStartIndex.Value, _selectionEndIndex.Value),
+            Math.Max(_selectionStartIndex.Value, _selectionEndIndex.Value));
+    }
+
+    // Pinned 在 Preview 事件中调用；其他 ImageZoom 保留原有的双击选行行为。
+    internal void SelectTextAtPoint(Point point, bool selectParagraph)
+    {
+        if (_interactionCanvas == null)
+            return;
+        var canvasPoint = TranslatePoint(point, _interactionCanvas);
+        var word = FindWordAtPoint(canvasPoint);
+        if (word == null)
+            return;
+        if (selectParagraph)
+        {
+            if (OcrWordSelection.TryGetParagraphRange(OcrWords, word, out var paragraphStart, out var paragraphEnd))
+            {
+                _isSelecting = false;
+                _selectionStartIndex = paragraphStart;
+                _selectionEndIndex = paragraphEnd;
+                UpdateSelectionHighlight();
+            }
+            return;
+        }
+        if (OcrWordSelection.TryGetWordRange(GetFullText(), CalculateCharacterIndexInWord(word, canvasPoint),
+                out var start, out var end))
+        {
+            // 软换行不应截断单词，但独立段落的文字不能合成一个词。
+            if (OcrWordSelection.TryGetParagraphRange(OcrWords, word, out var lineStart, out var lineEnd))
+            {
+                start = Math.Max(start, lineStart);
+                end = Math.Min(end, lineEnd);
+            }
+            _isSelecting = false;
+            _selectionStartIndex = start;
+            _selectionEndIndex = end;
+            UpdateSelectionHighlight();
+        }
+    }
+
     private bool SelectVisualLineAtPoint(Point point)
     {
         var anchorWord = FindWordAtPoint(point);
@@ -765,6 +830,13 @@ public class ImageZoom : Control
         if (transform == null || property == null)
             return;
 
+        if (DisableAnimation)
+        {
+            transform.BeginAnimation(property, null);
+            transform.SetCurrentValue(property, targetValue);
+            return;
+        }
+
         var duration = useAnimation && !DisableAnimation
             ? TimeSpan.FromMilliseconds(AnimationDurationMs)
             : TimeSpan.Zero;
@@ -779,7 +851,7 @@ public class ImageZoom : Control
 
     private void AnimateZoomHint()
     {
-        if (_scaleTextBorder == null)
+        if (_scaleTextBorder == null || AlwaysHideZoomValueHint || DisableAnimation)
             return;
 
         var duration = TimeSpan.FromMilliseconds(ZoomValueHintAnimationDurationMs);
@@ -1056,9 +1128,6 @@ public class ImageZoom : Control
 
     private void ResetSelection()
     {
-        if (OcrWords == null || OcrWords.Count == 0)
-            return;
-
         _isSelecting = false;
         _selectionStartIndex = null;
         _selectionEndIndex = null;
@@ -1078,7 +1147,7 @@ public class ImageZoom : Control
         UpdateSelectionHighlight();
     }
 
-    private string GetFullText()
+    internal string GetFullText()
     {
         if (_fullTextCache != null)
             return _fullTextCache;

--- a/src/STranslate/Core/HotkeySettings.cs
+++ b/src/STranslate/Core/HotkeySettings.cs
@@ -72,6 +72,8 @@ public partial class HotkeySettings : ObservableObject, IDisposable
 
     public Hotkey SwitchImageHotkey { get; set; } = new("Ctrl + OemQuestion");
 
+    public Hotkey PinImageTranslateHotkey { get; set; } = new(Constant.EmptyHotkey);
+
     #endregion
 
     [JsonIgnore]
@@ -106,6 +108,7 @@ public partial class HotkeySettings : ObservableObject, IDisposable
         new RegisteredHotkeyData(ReExecuteOcrHotkey.Key, "Hotkey_ReExecuteOcr", HotkeyType.OcrWindow | HotkeyType.ImageTransWindow, () => ReExecuteOcrHotkey.Key = Constant.EmptyHotkey),
         new RegisteredHotkeyData(QrCodeHotkey.Key, "Hotkey_QrCode", HotkeyType.OcrWindow, () => QrCodeHotkey.Key = Constant.EmptyHotkey),
         new RegisteredHotkeyData(SwitchImageHotkey.Key, "Hotkey_SwitchImage", HotkeyType.OcrWindow | HotkeyType.ImageTransWindow, () => SwitchImageHotkey.Key = Constant.EmptyHotkey),
+        new RegisteredHotkeyData(PinImageTranslateHotkey.Key, "Hotkey_PinImageTranslate", HotkeyType.ImageTransWindow, () => PinImageTranslateHotkey.Key = Constant.EmptyHotkey),
 
         //TODO: Other Window
     ];
@@ -211,6 +214,7 @@ public partial class HotkeySettings : ObservableObject, IDisposable
             [nameof(ReExecuteOcrHotkey)] = "Ctrl + R",
             [nameof(QrCodeHotkey)] = "Ctrl + Shift + R",
             [nameof(SwitchImageHotkey)] = "Ctrl + OemQuestion",
+            [nameof(PinImageTranslateHotkey)] = Constant.EmptyHotkey,
         };
         foreach (var prop in GetType().GetProperties())
         {

--- a/src/STranslate/Core/OcrLayoutAnalyzer.cs
+++ b/src/STranslate/Core/OcrLayoutAnalyzer.cs
@@ -138,6 +138,7 @@ internal static class OcrLayoutAnalyzer
                     Text = text,
                     BoxPoints = boxPoints,
                     LineBoxPoints = lineBoxPoints,
+                    SourceContents = lines.ToArray(),
                     Source = OcrLayoutSource.Provider,
                     Confidence = 1
                 });
@@ -155,6 +156,7 @@ internal static class OcrLayoutAnalyzer
                 Text = content.Text,
                 BoxPoints = CloneBoxPoints(content.BoxPoints),
                 LineBoxPoints = content.BoxPoints.Count > 0 ? [CloneBoxPoints(content.BoxPoints)] : [],
+                SourceContents = [content],
                 Source = OcrLayoutSource.NoMerge,
                 Confidence = 1
             })
@@ -1146,6 +1148,7 @@ internal static class OcrLayoutAnalyzer
                 Text = JoinParagraphText(Lines),
                 BoxPoints = CreateBoxPoints(bounds),
                 LineBoxPoints = Lines.Select(line => CreateBoxPoints(line.Bounds)).ToList(),
+                SourceContents = Lines.SelectMany(line => line.Items.Select(item => item.Content)).ToArray(),
                 Source = OcrLayoutSource.Smart,
                 Confidence = Confidence
             };

--- a/src/STranslate/Core/OcrLayoutBlock.cs
+++ b/src/STranslate/Core/OcrLayoutBlock.cs
@@ -17,6 +17,9 @@ internal sealed class OcrLayoutBlock
 
     public List<List<BoxPoint>> LineBoxPoints { get; set; } = [];
 
+    // 保留分析器已确定的原始文本归属，选择段落时无需按坐标重新推断。
+    internal IReadOnlyList<OcrContent> SourceContents { get; init; } = [];
+
     public OcrLayoutSource Source { get; set; }
 
     public double Confidence { get; set; } = 1;

--- a/src/STranslate/Core/OcrWord.cs
+++ b/src/STranslate/Core/OcrWord.cs
@@ -13,6 +13,8 @@ public class OcrWord
 
     internal int VisualLineIndex { get; set; } = -1;
 
+    internal int ParagraphIndex { get; set; } = -1;
+
     /// <summary>
     /// 该单词在全文中的起始索引
     /// </summary>

--- a/src/STranslate/Core/OcrWordBuilder.cs
+++ b/src/STranslate/Core/OcrWordBuilder.cs
@@ -7,6 +7,10 @@ namespace STranslate.Core;
 
 internal static class OcrWordBuilder
 {
+    internal static ObservableCollection<OcrWord> CreateFromLayoutBlocks(IReadOnlyList<OcrLayoutBlock> blocks) =>
+        CreateIndexedCollectionFromGroups(blocks.Select(block => CreateFromOcrContents(block.SourceContents)),
+            separateParagraphs: true);
+
     public static ObservableCollection<OcrWord> CreateFromOcrContents(IEnumerable<OcrContent>? contents)
     {
         if (contents == null)
@@ -58,7 +62,7 @@ internal static class OcrWordBuilder
         FormattedText formattedText,
         Point origin,
         Rect clipRect,
-        double scaleFactor)
+        double scaleFactor, bool preserveClippedText = false)
     {
         if (string.IsNullOrEmpty(text) ||
             clipRect.IsEmpty ||
@@ -76,14 +80,19 @@ internal static class OcrWordBuilder
             var bounds = geometry?.Bounds ?? Rect.Empty;
             if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
             {
-                if (char.IsWhiteSpace(text[i]))
+                // 裁剪/省略只影响命中框，不能删掉复制全文或整段所需的逻辑字符。
+                if (preserveClippedText || char.IsWhiteSpace(text[i]))
                     words.Add(CreateTextOnlyWord(text[i].ToString()));
                 continue;
             }
 
             var clippedBounds = Rect.Intersect(bounds, clipRect);
             if (clippedBounds.IsEmpty || clippedBounds.Width <= 0 || clippedBounds.Height <= 0)
+            {
+                if (preserveClippedText)
+                    words.Add(CreateTextOnlyWord(text[i].ToString()));
                 continue;
+            }
 
             words.Add(new OcrWord
             {
@@ -118,10 +127,11 @@ internal static class OcrWordBuilder
     }
 
     public static ObservableCollection<OcrWord> CreateIndexedCollectionFromGroups(
-        IEnumerable<IEnumerable<OcrWord>> wordGroups)
+        IEnumerable<IEnumerable<OcrWord>> wordGroups, bool separateParagraphs = false)
     {
         var indexedWords = new List<OcrWord>();
         var nextVisualLineIndex = 0;
+        var paragraphIndex = 0;
         foreach (var wordGroup in wordGroups)
         {
             var groupWords = wordGroup
@@ -129,6 +139,13 @@ internal static class OcrWordBuilder
                                (IsSelectableBounds(word.BoundingBox) || word.BoundingBox.IsEmpty))
                 .ToList();
 
+            if (groupWords.Count == 0)
+                continue;
+            if (separateParagraphs && indexedWords.Count > 0)
+                indexedWords.Add(CreateTextOnlyWord(Environment.NewLine));
+            foreach (var word in groupWords)
+                word.ParagraphIndex = paragraphIndex;
+            paragraphIndex++;
             AssignVisualLineIndexes(groupWords, ref nextVisualLineIndex);
             indexedWords.AddRange(groupWords);
         }

--- a/src/STranslate/Core/OcrWordSelection.cs
+++ b/src/STranslate/Core/OcrWordSelection.cs
@@ -1,7 +1,61 @@
+using System.Globalization;
+
 namespace STranslate.Core;
 
 internal static class OcrWordSelection
 {
+    internal static bool TryGetParagraphRange(IReadOnlyList<OcrWord>? words, OcrWord anchor,
+        out int start, out int end)
+    {
+        start = int.MaxValue;
+        end = -1;
+        if (words == null || anchor.ParagraphIndex < 0)
+            return false;
+        foreach (var word in words)
+        {
+            if (word.ParagraphIndex != anchor.ParagraphIndex || word.Text.Length == 0)
+                continue;
+            start = Math.Min(start, word.StartIndexInFullText);
+            end = Math.Max(end, word.EndIndexInFullText - 1);
+        }
+        return end >= start;
+    }
+
+    internal static bool TryGetWordRange(string text, int index, out int start, out int end)
+    {
+        start = 0;
+        end = -1;
+        if (index < 0 || index >= text.Length)
+            return false;
+
+        // 按 Unicode 文本元素取边界，避免切断代理对、emoji 和组合字符。
+        var elements = StringInfo.ParseCombiningCharacters(text);
+        var element = Array.BinarySearch(elements, index);
+        if (element < 0)
+            element = ~element - 1;
+        var first = element;
+        var last = element;
+        var kind = Classify(elements[element]);
+        while (first > 0 && Classify(elements[first - 1]) == kind)
+            first--;
+        while (last + 1 < elements.Length && Classify(elements[last + 1]) == kind)
+            last++;
+        start = elements[first];
+        end = (last + 1 < elements.Length ? elements[last + 1] : text.Length) - 1;
+        return true;
+
+        int Classify(int position)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(text, position);
+            if (char.IsWhiteSpace(text, position))
+                return text[position] is '\r' or '\n' ? 3 : 0;
+            return category is UnicodeCategory.UppercaseLetter or UnicodeCategory.LowercaseLetter or
+                UnicodeCategory.TitlecaseLetter or UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or
+                UnicodeCategory.DecimalDigitNumber or UnicodeCategory.LetterNumber or UnicodeCategory.ConnectorPunctuation
+                ? 1 : 2;
+        }
+    }
+
     internal static bool TryGetVisualLineRange(
         IReadOnlyList<OcrWord>? words,
         OcrWord? anchorWord,

--- a/src/STranslate/Core/PinnedWindowController.cs
+++ b/src/STranslate/Core/PinnedWindowController.cs
@@ -1,0 +1,171 @@
+using STranslate.Helpers;
+using STranslate.Plugin;
+using STranslate.Views;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using DrawingRectangle = System.Drawing.Rectangle;
+
+namespace STranslate.Core;
+
+/// <summary>只在 UI 线程管理静态贴图及截图避让，不参与 OCR 或翻译。</summary>
+public sealed class PinnedWindowController(Settings settings, Internationalization i18n, ISnackbar snackbar)
+{
+    private readonly HashSet<PinnedImageTranslateWindow> _windows = [];
+    private readonly SemaphoreSlim _captureGate = new(1, 1);
+    private bool _captureActive;
+
+    internal bool ShowShadow
+    {
+        get => settings.PinnedImageTranslateShowShadow;
+        set => settings.PinnedImageTranslateShowShadow = value;
+    }
+
+    internal void CopyText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+        try
+        {
+            Clipboard.SetText(text);
+        }
+        catch (System.Runtime.InteropServices.ExternalException ex)
+        {
+            snackbar.ShowError($"{i18n.GetTranslation("CopyFailed")}: {ex.Message}");
+        }
+    }
+
+    internal PinnedImageTranslateWindow CreateWindow(PinnedImageTranslateSnapshot snapshot)
+    {
+        Application.Current.Dispatcher.VerifyAccess();
+        var window = new PinnedImageTranslateWindow(this);
+        _windows.Add(window);
+        try
+        {
+            window.Initialize(snapshot, ShowShadow);
+            window.ShowActivated = !_captureActive;
+            window.Show();
+            return window;
+        }
+        catch
+        {
+            window.Close();
+            throw;
+        }
+    }
+
+    internal void Unregister(PinnedImageTranslateWindow window) => _windows.Remove(window);
+
+    internal void OnWindowSourceInitialized(PinnedImageTranslateWindow window)
+    {
+        if (_captureActive && !window.SetCaptureCloaked(true))
+            throw new InvalidOperationException("Failed to cloak a pinned window during capture.");
+    }
+
+    internal async ValueTask<IAsyncDisposable?> BeginCaptureAsync(CancellationToken cancellationToken = default)
+    {
+        // 同一截图尚未结束时忽略重复触发，不把旧输入排队成下一次截图。
+        if (!await _captureGate.WaitAsync(0, cancellationToken))
+            return null;
+        try
+        {
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                _captureActive = true;
+                foreach (var window in _windows)
+                {
+                    window.CloseTransientUiForCapture();
+                    if (!window.SetCaptureCloaked(true))
+                        throw new InvalidOperationException("Failed to cloak a pinned window before capture.");
+                }
+                if (_windows.Count > 0)
+                    Win32Helper.FlushDesktopComposition();
+            });
+            return new CaptureLease(this);
+        }
+        catch
+        {
+            await EndCaptureAsync();
+            throw;
+        }
+    }
+
+    internal void CloseAll()
+    {
+        if (!Application.Current.Dispatcher.CheckAccess())
+        {
+            Application.Current.Dispatcher.Invoke(CloseAll);
+            return;
+        }
+        foreach (var window in _windows.ToArray())
+            window.Close();
+    }
+
+    private async ValueTask EndCaptureAsync()
+    {
+        try
+        {
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                _captureActive = false;
+                var restored = true;
+                foreach (var window in _windows)
+                    restored &= window.SetCaptureCloaked(false);
+                if (_windows.Count > 0)
+                    Win32Helper.FlushDesktopComposition();
+                if (!restored)
+                    throw new InvalidOperationException("Failed to restore pinned windows after capture.");
+            });
+        }
+        finally
+        {
+            _captureGate.Release();
+        }
+    }
+
+    private sealed class CaptureLease(PinnedWindowController owner) : IAsyncDisposable
+    {
+        private PinnedWindowController? _owner = owner;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _owner, null) is { } current)
+                await current.EndCaptureAsync();
+        }
+    }
+}
+
+/// <summary>已生成结果的独立显示快照；图片冻结，选择数据逐项复制。</summary>
+internal sealed record PinnedImageTranslateSnapshot(
+    BitmapSource SourceImage,
+    BitmapSource AnnotatedImage,
+    ImageTranslateOverlayDocument TranslationOverlay,
+    IReadOnlyList<OcrWord> OriginalWords,
+    IReadOnlyList<OcrWord> TranslatedWords,
+    DrawingRectangle PhysicalBounds,
+    bool ShowOriginal)
+{
+    internal static PinnedImageTranslateSnapshot Create(
+        BitmapSource source, BitmapSource annotated, ImageTranslateOverlayDocument overlay,
+        IReadOnlyList<OcrWord> originalWords, IReadOnlyList<OcrWord> translatedWords,
+        DrawingRectangle bounds, bool showOriginal = false)
+    {
+        if (bounds.Width <= 0 || bounds.Height <= 0 ||
+            source.PixelWidth != bounds.Width || source.PixelHeight != bounds.Height ||
+            annotated.PixelWidth != bounds.Width || annotated.PixelHeight != bounds.Height ||
+            !source.IsFrozen || !annotated.IsFrozen || overlay.IsEmpty)
+            throw new ArgumentException("Pin requires a frozen, completed result matching the physical image bounds.");
+
+        return new(source, annotated, new ImageTranslateOverlayDocument(overlay.Items.ToArray(), []),
+            CloneWords(originalWords), CloneWords(translatedWords), bounds, showOriginal);
+    }
+
+    private static IReadOnlyList<OcrWord> CloneWords(IReadOnlyList<OcrWord> words) =>
+        Array.AsReadOnly(words.Select(word => new OcrWord
+        {
+            Text = word.Text,
+            BoundingBox = word.BoundingBox,
+            StartIndexInFullText = word.StartIndexInFullText,
+            VisualLineIndex = word.VisualLineIndex,
+            ParagraphIndex = word.ParagraphIndex,
+        }).ToArray());
+}

--- a/src/STranslate/Core/Screenshot.cs
+++ b/src/STranslate/Core/Screenshot.cs
@@ -4,7 +4,7 @@ using System.Windows;
 
 namespace STranslate.Core;
 
-public class Screenshot(Settings settings) : IScreenshot
+public class Screenshot(Settings settings, PinnedWindowController pinnedWindowController) : IScreenshot
 {
     private const int DefaultCaptureDelayMs = 150;
 
@@ -25,7 +25,9 @@ public class Screenshot(Settings settings) : IScreenshot
 
     public async Task<ScreenshotCaptureResult?> GetScreenshotCaptureAsync()
     {
-        if (ScreenGrabber.IsCapturing)
+        await using var captureScope = await pinnedWindowController.BeginCaptureAsync();
+
+        if (captureScope == null || ScreenGrabber.IsCapturing)
             return default;
 
         if (App.Current.MainWindow.Visibility == Visibility.Visible &&
@@ -39,7 +41,7 @@ public class Screenshot(Settings settings) : IScreenshot
         // 因此关闭 ScreenGrab 对 <64px 小截图的 padding 扩展，
         // 否则 padding 后的 bitmap 会被 Viewbox 缩放，导致原始内容被缩小。
         // 其他窗口模式保留默认 padding 行为以兼容历史。
-        var padImage = settings.ImageTranslateWindowMode != ImageTranslateWindowMode.Compact;
+        var padImage = ShouldPadImage(settings.ImageTranslateWindowMode);
 
         // CaptureWithRegionAsync 直接回传截图选区的物理屏幕坐标，
         // 无需事后反推（旧版 CaptureAsync 只回传 bitmap）。
@@ -50,9 +52,14 @@ public class Screenshot(Settings settings) : IScreenshot
         return new ScreenshotCaptureResult(capture.Bitmap, capture.Region);
     }
 
+    internal static bool ShouldPadImage(ImageTranslateWindowMode mode) =>
+        mode != ImageTranslateWindowMode.Compact;
+
     private async Task<Bitmap?> CaptureBitmapAsync()
     {
-        if (ScreenGrabber.IsCapturing)
+        await using var captureScope = await pinnedWindowController.BeginCaptureAsync();
+
+        if (captureScope == null || ScreenGrabber.IsCapturing)
             return default;
 
         if (App.Current.MainWindow.Visibility == Visibility.Visible &&

--- a/src/STranslate/Core/Settings.cs
+++ b/src/STranslate/Core/Settings.cs
@@ -277,6 +277,7 @@ public partial class Settings : ObservableObject
     [ObservableProperty] public partial bool IsImTranShowingTextControl { get; set; } = false;
     [ObservableProperty] public partial LangEnum ImageTranslateOcrLanguage { get; set; } = LangEnum.Auto;
     [ObservableProperty] public partial bool IsImageTranslateCompactOcrLanguageVisible { get; set; } = false;
+    [ObservableProperty] public partial bool PinnedImageTranslateShowShadow { get; set; } = true;
     [ObservableProperty] public partial LangEnum ImageTranslateSourceLang { get; set; } = LangEnum.Auto;
     [ObservableProperty] public partial LangEnum ImageTranslateTargetLang { get; set; } = LangEnum.Auto;
 

--- a/src/STranslate/Helpers/ImageTranslateRenderer.cs
+++ b/src/STranslate/Helpers/ImageTranslateRenderer.cs
@@ -110,7 +110,7 @@ internal static class ImageTranslateRenderer
                     overlay.FormattedText,
                     overlay.TextPosition,
                     overlay.Plan.TextClipRect,
-                    scaleFactor: 1)));
+                    scaleFactor: 1, preserveClippedText: true)), separateParagraphs: true);
 
         return new ImageTranslateOverlayDocument(
             overlays.ToArray(),

--- a/src/STranslate/Helpers/Win32Helper.cs
+++ b/src/STranslate/Helpers/Win32Helper.cs
@@ -180,6 +180,8 @@ public static class Win32Helper
     #region Window Position
 
     private const uint SWP_NOZORDER = 0x0004;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
     private const uint SWP_NOACTIVATE = 0x0010;
     private const uint SWP_SHOWWINDOW = 0x0040;
     private const uint MONITOR_DEFAULTTONEAREST = 2;
@@ -231,6 +233,79 @@ public static class Win32Helper
         }
     }
 
+    /// <summary>
+    /// 在同一个 DeferWindowPos batch 中更新两个 HWND 的物理矩形。
+    /// 用于 Pinned 主内容窗与视觉 Chrome 伴随窗，避免快速拖动时两个窗口逐次 SetWindowPos 造成可见迟滞。
+    /// </summary>
+    internal static bool SetTwoWindowPhysicalBounds(
+        Window firstWindow,
+        System.Drawing.Rectangle firstBounds,
+        Window secondWindow,
+        System.Drawing.Rectangle secondBounds)
+    {
+        var first = new WindowInteropHelper(firstWindow).EnsureHandle();
+        var second = new WindowInteropHelper(secondWindow).EnsureHandle();
+        var deferred = BeginDeferWindowPos(2);
+        if (deferred == 0)
+            return false;
+
+        deferred = DeferWindowPos(
+            deferred,
+            first,
+            0,
+            firstBounds.Left,
+            firstBounds.Top,
+            Math.Max(1, firstBounds.Width),
+            Math.Max(1, firstBounds.Height),
+            SWP_NOZORDER | SWP_NOACTIVATE);
+        if (deferred == 0)
+            return false;
+
+        deferred = DeferWindowPos(
+            deferred,
+            second,
+            0,
+            secondBounds.Left,
+            secondBounds.Top,
+            Math.Max(1, secondBounds.Width),
+            Math.Max(1, secondBounds.Height),
+            SWP_NOZORDER | SWP_NOACTIVATE);
+        return deferred != 0 && EndDeferWindowPos(deferred);
+    }
+
+    internal static bool PlaceWindowBehind(Window window, Window windowAbove)
+    {
+        var hwnd = new WindowInteropHelper(window).EnsureHandle();
+        var above = new WindowInteropHelper(windowAbove).EnsureHandle();
+        return PlaceWindowBehind(hwnd, above);
+    }
+
+    internal static bool PlaceWindowBehind(nint hwnd, nint windowAbove)
+    {
+        if (hwnd == 0 || windowAbove == 0)
+            return false;
+
+        return SetWindowPos(
+            hwnd,
+            windowAbove,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    }
+
+    internal static void ConfigureClickThroughNoActivate(Window window)
+    {
+        var hwnd = GetWindowHandle(window, ensure: true);
+        var exStyle = GetWindowStyle(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE).ToInt64();
+        exStyle |= (long)(uint)WINDOW_EX_STYLE.WS_EX_TRANSPARENT;
+        exStyle |= (long)(uint)WINDOW_EX_STYLE.WS_EX_NOACTIVATE;
+        exStyle |= (long)(uint)WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
+        exStyle &= ~(long)(uint)WINDOW_EX_STYLE.WS_EX_APPWINDOW;
+        SetWindowStyle(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, new nint(exStyle));
+    }
+
     internal static unsafe bool SetWindowCloaked(Window window, bool cloaked)
     {
         var value = cloaked ? 1 : 0;
@@ -261,6 +336,24 @@ public static class Win32Helper
         int cx,
         int cy,
         uint flags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern nint BeginDeferWindowPos(int nNumWindows);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern nint DeferWindowPos(
+        nint hWinPosInfo,
+        nint hWnd,
+        nint hWndInsertAfter,
+        int x,
+        int y,
+        int cx,
+        int cy,
+        uint uFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EndDeferWindowPos(nint hWinPosInfo);
 
     [DllImport("user32.dll")]
     private static extern HMONITOR MonitorFromPoint(NativePoint pt, uint flags);

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -219,6 +219,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | Image Translation Window Hotkey</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">Re-execute Text Recognition | Image Translation</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">Switch Rendering/Annotation Image</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">Pin image translation (Compact)</sys:String>
     <sys:String x:Key="Hotkey_QrCode">Recognize QR Code</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">This hotkey is only supported in OCR window</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">Incremental Translation</sys:String>

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -868,4 +868,10 @@
     <sys:String x:Key="EditPrompt_Content">Edit</sys:String>
     <sys:String x:Key="Temperature">Temperature Control</sys:String>
     <sys:String x:Key="Temperature_Description">Controls the randomness of the model's output</sys:String>
+    <sys:String x:Key="ImageTranslatePin">Pin</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">Could not pin the result</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">Copy all text</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">Show original image</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">Show translation</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">Window shadow</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/fa.xaml
+++ b/src/STranslate/Languages/fa.xaml
@@ -220,6 +220,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">کلید میانبر پنجره OCR | ترجمه تصویر</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">اجرای مجدد تشخیص متن | ترجمه تصویر</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">سوئیچ بین تصویر رندرشده / نشانه‌گذاری‌شده</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">سنجاق کردن ترجمهٔ تصویر (فشرده)</sys:String>
     <sys:String x:Key="Hotkey_QrCode">تشخیص کُد QR</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">این کلید میانبر فقط در پنجره OCR پشتیبانی می‌شود</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">ترجمه افزایشی</sys:String>

--- a/src/STranslate/Languages/fa.xaml
+++ b/src/STranslate/Languages/fa.xaml
@@ -885,4 +885,10 @@ Alt+کلیک چپ -> تنظیمات ترجمه متن</sys:String>
     <sys:String x:Key="EditPrompt_Content">ویرایش</sys:String>
     <sys:String x:Key="Temperature">میزان خلاقیت (Temperature)</sys:String>
     <sys:String x:Key="Temperature_Description">کنترل میزان تصادفی بودن خروجی مدل</sys:String>
+    <sys:String x:Key="ImageTranslatePin">سنجاق</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">سنجاق نتیجه ناموفق بود</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">کپی تمام متن</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">نمایش تصویر اصلی</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">نمایش ترجمه</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">سایه پنجره</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -844,4 +844,10 @@
     <sys:String x:Key="EditPrompt_Content">編集</sys:String>
     <sys:String x:Key="Temperature">温度 (Temperature)</sys:String>
     <sys:String x:Key="Temperature_Description">モデル出力のランダム性を制御します</sys:String>
+    <sys:String x:Key="ImageTranslatePin">ピン留め</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">ピン留めに失敗しました</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">全文をコピー</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">元画像を表示</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">翻訳を表示</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">ウィンドウの影</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -215,6 +215,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | 画像翻訳画面ホットキー</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">文字認識 | 画像翻訳を再実行</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">レンダリング画像/マークアップ画像の切替</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">画像翻訳をピン留め（コンパクト）</sys:String>
     <sys:String x:Key="Hotkey_QrCode">QRコード認識</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">このホットキーはOCR画面でのみ有効です。</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">増分翻訳</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -844,4 +844,10 @@
     <sys:String x:Key="EditPrompt_Content">편집</sys:String>
     <sys:String x:Key="Temperature">온도 (Temperature)</sys:String>
     <sys:String x:Key="Temperature_Description">모델 출력의 무작위성을 제어합니다</sys:String>
+    <sys:String x:Key="ImageTranslatePin">고정</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">고정하지 못했습니다</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">전체 텍스트 복사</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">원본 이미지 표시</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">번역 표시</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">창 그림자</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -215,6 +215,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | 이미지 번역 창 단축키</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">텍스트 인식 | 이미지 번역 재실행</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">렌더링 이미지/마킹 이미지 전환</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">이미지 번역 고정 (간소화 창)</sys:String>
     <sys:String x:Key="Hotkey_QrCode">QR 코드 인식</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">이 단축키는 OCR 창에서만 지원됩니다.</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">증분 번역</sys:String>

--- a/src/STranslate/Languages/ru.xaml
+++ b/src/STranslate/Languages/ru.xaml
@@ -868,4 +868,10 @@
     <sys:String x:Key="EditPrompt_Content">Изменить</sys:String>
     <sys:String x:Key="Temperature">Температура</sys:String>
     <sys:String x:Key="Temperature_Description">Управляет случайностью ответов модели</sys:String>
+    <sys:String x:Key="ImageTranslatePin">Закрепить</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">Не удалось закрепить</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">Копировать весь текст</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">Показать оригинал</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">Показать перевод</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">Тень окна</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/ru.xaml
+++ b/src/STranslate/Languages/ru.xaml
@@ -219,6 +219,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">Горячие клавиши окна распознавания текста | перевода изображения</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">Повторить распознавание текста | перевод изображения</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">Переключить изображение (результат/разметка)</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">Закрепить перевод изображения (компактное окно)</sys:String>
     <sys:String x:Key="Hotkey_QrCode">Распознать QR-код</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">Работает только в окне распознавания текста</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">Накопительный перевод</sys:String>

--- a/src/STranslate/Languages/tr.xaml
+++ b/src/STranslate/Languages/tr.xaml
@@ -219,6 +219,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | Görsel Çeviri Penceresi Kısayolu</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">Metin Tanımayı | Görsel Çeviriyi Yeniden Çalıştır</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">İşleme/Not Görüntüsünü Değiştir</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">Görüntü çevirisini sabitle (Kompakt)</sys:String>
     <sys:String x:Key="Hotkey_QrCode">QR Kodu Tanı</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">Bu kısayol yalnızca OCR penceresinde desteklenir.</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">Kademeli Çeviri</sys:String>

--- a/src/STranslate/Languages/tr.xaml
+++ b/src/STranslate/Languages/tr.xaml
@@ -870,4 +870,10 @@
     <sys:String x:Key="EditPrompt_Content">Düzenle</sys:String>
     <sys:String x:Key="Temperature">Sıcaklık Kontrolü</sys:String>
     <sys:String x:Key="Temperature_Description">Modelin çıktısının rastgeleliğini kontrol eder.</sys:String>
+    <sys:String x:Key="ImageTranslatePin">Sabitle</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">Sonuç sabitlenemedi</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">Tüm metni kopyala</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">Orijinal resmi göster</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">Çeviriyi göster</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">Pencere gölgesi</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -219,6 +219,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | 图片翻译窗口快捷键</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">重新执行文本识别 | 图片翻译</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">切换渲染图/标注图</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">贴图（精简图片翻译窗口）</sys:String>
     <sys:String x:Key="Hotkey_QrCode">识别二维码</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">该热键仅支持OCR窗口</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">增量翻译</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -869,4 +869,10 @@
     <sys:String x:Key="EditPrompt_Content">编辑</sys:String>
     <sys:String x:Key="Temperature">温度控制</sys:String>
     <sys:String x:Key="Temperature_Description">控制着模型输出的随机性</sys:String>
+    <sys:String x:Key="ImageTranslatePin">贴图</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">贴图失败</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">复制全文</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">显示原图</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">显示译文</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">窗口阴影</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -871,4 +871,10 @@
     <sys:String x:Key="EditPrompt_Content">編輯</sys:String>
     <sys:String x:Key="Temperature">溫度控制</sys:String>
     <sys:String x:Key="Temperature_Description">控制著模型輸出的隨機性</sys:String>
+    <sys:String x:Key="ImageTranslatePin">貼圖</sys:String>
+    <sys:String x:Key="ImageTranslatePinFailed">貼圖失敗</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedCopyAll">複製全文</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowOriginal">顯示原圖</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedShowTranslation">顯示譯文</sys:String>
+    <sys:String x:Key="ImageTranslatePinnedWindowShadow">視窗陰影</sys:String>
 </ResourceDictionary>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -219,6 +219,7 @@
     <sys:String x:Key="Hotkey_OcrImTransWindow">OCR | 圖片翻譯視窗快捷鍵</sys:String>
     <sys:String x:Key="Hotkey_ReExecuteOcr">重新執行文字識別 | 圖片翻譯</sys:String>
     <sys:String x:Key="Hotkey_SwitchImage">切換渲染圖/標註圖</sys:String>
+    <sys:String x:Key="Hotkey_PinImageTranslate">貼圖（精簡圖片翻譯視窗）</sys:String>
     <sys:String x:Key="Hotkey_QrCode">識別二維碼</sys:String>
     <sys:String x:Key="Hotkey_QrCodeDescription">該熱鍵僅支援OCR視窗</sys:String>
     <sys:String x:Key="Hotkey_IncrementalTranslate">增量翻譯</sys:String>

--- a/src/STranslate/ViewModels/ImageTranslateWindowViewModel.cs
+++ b/src/STranslate/ViewModels/ImageTranslateWindowViewModel.cs
@@ -104,7 +104,22 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
     public partial bool IsShowingFitToWindow { get; set; } = false;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanPin))]
     public partial bool IsExecuting { get; set; } = false;
+
+    public bool CanPin => !IsExecuting && !_disposed &&
+        _sourceImage != null && _annotatedImage != null && _resultOverlayDocument is { IsEmpty: false };
+    internal BitmapSource? SourceImage => _sourceImage;
+    internal BitmapSource? AnnotatedImage => _annotatedImage;
+    internal ImageTranslateOverlayDocument? ResultOverlay => _resultOverlayDocument;
+    internal IReadOnlyList<OcrWord> OriginalSelectionWords => _originalSelectionWords;
+    internal IReadOnlyList<OcrWord> TranslatedSelectionWords => _translatedSelectionWords;
+
+    internal void ReportPinFailure(Exception exception)
+    {
+        _logger.LogError(exception, "Failed to pin image translation");
+        _snackbar.ShowError($"{_i18n.GetTranslation("ImageTranslatePinFailed")}: {exception.Message}");
+    }
 
     [ObservableProperty]
     public partial string ProcessRingText { get; set; } = string.Empty;
@@ -184,6 +199,7 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
             _lastOcrResult = await ocrSvc.RecognizeAsync(
                 new OcrRequest(data, Settings.ImageTranslateOcrLanguage, bitmap.Width, bitmap.Height),
                 cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             Utilities.PrepareOcrResult(_lastOcrResult);
 
             if (!_lastOcrResult.IsSuccess || string.IsNullOrEmpty(_lastOcrResult.Text))
@@ -196,9 +212,6 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
             if (Settings.CopyAfterOcr)
                 ClipboardHelper.SetText(_lastOcrResult.Text);
 
-            _originalSelectionWords = OcrWordBuilder.CreateFromOcrContents(_lastOcrResult.OcrContents);
-            RefreshSelectableOcrWords();
-
             IsNoLocationInfoVisible = !Utilities.HasBoxPoints(_lastOcrResult);
 
             // 生成原始OCR标注图像（显示识别边框）
@@ -206,6 +219,8 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
 
             // 分段逻辑
             var layoutBlocks = ApplyLayoutAnalysis(_lastOcrResult);
+            _originalSelectionWords = OcrWordBuilder.CreateFromLayoutBlocks(layoutBlocks);
+            RefreshSelectableOcrWords();
 
             // 生成分段后的标注图像（显示合并后的边框）
             _annotatedImage = ImageTranslateRenderer.GenerateAnnotatedImage(_lastOcrResult, _sourceImage);
@@ -260,6 +275,8 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
                 }
             });
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             _lastOcrResult.OcrContents.Clear();
             _lastOcrResult.OcrContents.AddRange(layoutBlocks.Select(x => x.ToOcrContent()));
 
@@ -272,7 +289,7 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
 
             RefreshDisplayState();
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             //TODO: 考虑提示用户取消操作
         }
@@ -660,6 +677,7 @@ public partial class ImageTranslateWindowViewModel : ObservableObject, IDisposab
         _originalSelectionWords = [];
         _translatedSelectionWords = [];
         OcrWords = [];
+        OnPropertyChanged(nameof(CanPin));
     }
 
     private void RefreshSelectableOcrWords()

--- a/src/STranslate/Views/ImageTranslateCompactWindow.xaml
+++ b/src/STranslate/Views/ImageTranslateCompactWindow.xaml
@@ -28,6 +28,10 @@
     mc:Ignorable="d">
     <Window.InputBindings>
         <KeyBinding
+            Key="{Binding HotkeySettings.PinImageTranslateHotkey.Key, Converter={cnvt:StringToKeyBindingConverter}, ConverterParameter={x:Static cnvt:HotkeyMode.Key}}"
+            Command="{Binding Command, ElementName=PART_PinButton}"
+            Modifiers="{Binding HotkeySettings.PinImageTranslateHotkey.Key, Converter={cnvt:StringToKeyBindingConverter}, ConverterParameter={x:Static cnvt:HotkeyMode.Modifiers}}" />
+        <KeyBinding
             Key="Esc"
             Command="{Binding CancelCommand}"
             CommandParameter="{Binding ElementName=STImageTranslateCompactWindow}" />

--- a/src/STranslate/Views/ImageTranslateCompactWindow.xaml
+++ b/src/STranslate/Views/ImageTranslateCompactWindow.xaml
@@ -234,6 +234,13 @@
                     Style="{StaticResource CompactToolbarComboBoxStyle}"
                     ToolTip="{DynamicResource TranslateLanguage}" />
                 <control:IconButton
+                    x:Name="PART_PinButton"
+                    AutomationProperties.Name="{DynamicResource ImageTranslatePin}"
+                    Icon="{x:Static ui:FluentSystemIcons.Pin_24_Regular}"
+                    IsEnabled="{Binding CanPin}"
+                    Style="{StaticResource CompactToolbarIconButtonStyle}"
+                    ToolTip="{DynamicResource ImageTranslatePin}" />
+                <control:IconButton
                     Command="{Binding CancelCommand}"
                     CommandParameter="{Binding ElementName=STImageTranslateCompactWindow}"
                     Icon="{x:Static ui:FluentSystemIcons.Dismiss_20_Regular}"

--- a/src/STranslate/Views/ImageTranslateCompactWindow.xaml.cs
+++ b/src/STranslate/Views/ImageTranslateCompactWindow.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
 using STranslate.Core;
 using STranslate.Helpers;
@@ -44,10 +45,13 @@ public partial class ImageTranslateCompactWindow
     private bool _isClosing;
     private CompactWindowLayout? _layout;
     private DrawingRectangle? _pendingPhysicalBounds;
+    private DrawingRectangle _imagePhysicalBounds;
+    private bool _isPinning;
 
     private bool ShouldSuppressAutoClose =>
         _isContextMenuOpen ||
         _isToolbarDropDownOpen ||
+        _isPinning ||
         _viewModel.IsSaveDialogOpen ||
         _isClosing;
 
@@ -58,6 +62,7 @@ public partial class ImageTranslateCompactWindow
         DataContext = _viewModel;
 
         InitializeComponent();
+        PART_PinButton.Command = new RelayCommand(PinCurrentResult);
     }
 
     public void PlaceForCapture(DrawingRectangle? physicalBounds, DrawingSize bitmapSize)
@@ -116,6 +121,7 @@ public partial class ImageTranslateCompactWindow
 
     private void PlaceOnPhysicalBounds(DrawingRectangle bounds)
     {
+        _imagePhysicalBounds = bounds;
         var dpiScale = GetDpiScale(bounds);
         var workArea = GetPhysicalWorkArea(
             bounds.Left + bounds.Width / 2,
@@ -210,7 +216,33 @@ public partial class ImageTranslateCompactWindow
             FallbackScreenWidthRatio,
             FallbackScreenHeightRatio);
 
-        PlaceOnPhysicalWindowBounds(windowBounds, dpiScale);
+        PlaceOnPhysicalBounds(new DrawingRectangle(windowBounds.Location, bitmapSize));
+    }
+
+    private void PinCurrentResult()
+    {
+        if (_isPinning || _isClosing || !_viewModel.CanPin)
+            return;
+
+        _isPinning = true;
+        try
+        {
+            var snapshot = PinnedImageTranslateSnapshot.Create(
+                _viewModel.SourceImage!, _viewModel.AnnotatedImage!, _viewModel.ResultOverlay!,
+                _viewModel.OriginalSelectionWords, _viewModel.TranslatedSelectionWords, _imagePhysicalBounds,
+                _viewModel.Settings.IsImTranShowingAnnotated);
+            Ioc.Default.GetRequiredService<PinnedWindowController>().CreateWindow(snapshot);
+            Close();
+        }
+        catch (Exception ex)
+        {
+            Activate();
+            _viewModel.ReportPinFailure(ex);
+        }
+        finally
+        {
+            _isPinning = false;
+        }
     }
 
     /// <summary>

--- a/src/STranslate/Views/Pages/HotkeyPage.xaml
+++ b/src/STranslate/Views/Pages/HotkeyPage.xaml
@@ -362,6 +362,13 @@
                                 ValidateKeyGesture="False"
                                 WindowTitle="{DynamicResource Hotkey_QrCode}" />
                         </ui:SettingsCard>
+                        <ui:SettingsCard Header="{DynamicResource Hotkey_PinImageTranslate}">
+                            <control:HotkeyControl
+                                DefaultHotkey="{Binding HotkeySettings.PinImageTranslateHotkey.Default}"
+                                Hotkey="{Binding HotkeySettings.PinImageTranslateHotkey.Key}"
+                                Type="ImageTransWindow"
+                                WindowTitle="{DynamicResource Hotkey_PinImageTranslate}" />
+                        </ui:SettingsCard>
                     </ui:SettingsExpander.Items>
                 </ui:SettingsExpander>
             </ikw:SimpleStackPanel>

--- a/src/STranslate/Views/PinnedImageTranslateChromeWindow.cs
+++ b/src/STranslate/Views/PinnedImageTranslateChromeWindow.cs
@@ -1,6 +1,5 @@
 using STranslate.Helpers;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Effects;
 using DrawingRectangle = System.Drawing.Rectangle;
@@ -15,10 +14,7 @@ internal sealed class PinnedImageTranslateChromeWindow : Window
     // 为阴影与辉光预留的外围区域。
     private const double ChromeMarginDip = 10;
 
-    private static readonly Color ActiveGlowColor = Color.FromRgb(0x4D, 0x90, 0xFE);
-
-    private readonly Border _shadowCaster;
-    private readonly Border _activeGlowCaster;
+    private readonly ChromeSurface _surface = new();
     private bool _isActive;
     private bool _isShadowEnabled = true;
     private bool _sourceInitialized;
@@ -36,45 +32,7 @@ internal sealed class PinnedImageTranslateChromeWindow : Window
         Focusable = false;
         Topmost = true;
 
-        _shadowCaster = new Border
-        {
-            Margin = new Thickness(ChromeMarginDip),
-            Background = Brushes.White,
-            IsHitTestVisible = false,
-            Effect = new DropShadowEffect
-            {
-                BlurRadius = 8,
-                Direction = 0,
-                Opacity = 0.36,
-                ShadowDepth = 0,
-                RenderingBias = RenderingBias.Performance,
-                Color = Colors.Black,
-            },
-        };
-
-        var activeGlowBrush = new SolidColorBrush(ActiveGlowColor);
-        activeGlowBrush.Freeze();
-        _activeGlowCaster = new Border
-        {
-            Margin = new Thickness(ChromeMarginDip),
-            Background = activeGlowBrush,
-            IsHitTestVisible = false,
-            Visibility = Visibility.Collapsed,
-            Effect = new DropShadowEffect
-            {
-                BlurRadius = 6,
-                Direction = 0,
-                Opacity = 0.42,
-                ShadowDepth = 0,
-                RenderingBias = RenderingBias.Quality,
-                Color = ActiveGlowColor,
-            },
-        };
-
-        var root = new Grid { IsHitTestVisible = false };
-        root.Children.Add(_shadowCaster);
-        root.Children.Add(_activeGlowCaster);
-        Content = root;
+        Content = _surface;
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -100,10 +58,8 @@ internal sealed class PinnedImageTranslateChromeWindow : Window
 
         _isActive = isActive;
         _isShadowEnabled = isShadowEnabled;
-        _activeGlowCaster.Visibility = _isActive ? Visibility.Visible : Visibility.Collapsed;
-        _shadowCaster.Visibility = !_isActive && _isShadowEnabled
-            ? Visibility.Visible
-            : Visibility.Collapsed;
+        _surface.Update(isActive);
+        _surface.Visibility = ShouldBeVisible ? Visibility.Visible : Visibility.Collapsed;
         UpdateVisibility();
     }
 
@@ -192,4 +148,101 @@ internal sealed class PinnedImageTranslateChromeWindow : Window
         }
     }
 
+    /// <summary>沿用原 WPF 模糊效果，仅为四周可见区域分配中间表面。</summary>
+    private sealed class ChromeSurface : FrameworkElement
+    {
+        private static readonly Color GlowColor = Color.FromRgb(0x4D, 0x90, 0xFE);
+        private static readonly Brush GlowBrush = CreateGlowBrush();
+        private static readonly DropShadowEffect Shadow = CreateEffect(Colors.Black, 8, 0.36, RenderingBias.Performance);
+        private static readonly DropShadowEffect Glow = CreateEffect(GlowColor, 6, 0.42, RenderingBias.Quality);
+        private readonly ContainerVisual[] _clips = new ContainerVisual[4];
+        private readonly DrawingVisual[] _casters = new DrawingVisual[4];
+        private bool _active;
+        private Rect _center = Rect.Empty;
+
+        internal ChromeSurface()
+        {
+            IsHitTestVisible = false;
+            for (var i = 0; i < 4; i++)
+            {
+                // 与原 Border 的 Margin 使用相同的局部原点，保留小数 DPI 下的采样位置。
+                _casters[i] = new DrawingVisual { Effect = Shadow, Offset = new Vector(ChromeMarginDip, ChromeMarginDip) };
+                _clips[i] = new ContainerVisual();
+                _clips[i].Children.Add(_casters[i]);
+                AddVisualChild(_clips[i]);
+            }
+        }
+
+        internal void Update(bool active)
+        {
+            if (_active == active)
+                return;
+            _active = active;
+            foreach (var caster in _casters)
+                caster.Effect = active ? Glow : Shadow;
+            UpdateDrawing();
+        }
+
+        protected override int VisualChildrenCount => _clips.Length;
+        protected override Visual GetVisualChild(int index) => _clips[index];
+
+        protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
+        {
+            base.OnDpiChanged(oldDpi, newDpi);
+            UpdateDrawing();
+        }
+
+        protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+        {
+            base.OnRenderSizeChanged(sizeInfo);
+            UpdateDrawing();
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            if (!_center.IsEmpty)
+                drawingContext.DrawRectangle(_active ? GlowBrush : Brushes.White, null, _center);
+        }
+
+        private void UpdateDrawing()
+        {
+            if (ActualWidth < 2 * ChromeMarginDip || ActualHeight < 2 * ChromeMarginDip)
+                return;
+            var dpi = VisualTreeHelper.GetDpi(this);
+            var left = Math.Ceiling(ChromeMarginDip * dpi.DpiScaleX) / dpi.DpiScaleX;
+            var top = Math.Ceiling(ChromeMarginDip * dpi.DpiScaleY) / dpi.DpiScaleY;
+            var right = Math.Floor((ActualWidth - ChromeMarginDip) * dpi.DpiScaleX) / dpi.DpiScaleX;
+            var bottom = Math.Floor((ActualHeight - ChromeMarginDip) * dpi.DpiScaleY) / dpi.DpiScaleY;
+            _center = new Rect(left, top, Math.Max(0, right - left), Math.Max(0, bottom - top));
+            var brush = _active ? GlowBrush : Brushes.White;
+            // 中央已是完全不透明的实色；分界落在物理像素上，避免裁剪边缘重复混合。
+            Rect[] clips = [new(0, 0, ActualWidth, top), new(0, bottom, ActualWidth, ActualHeight - bottom),
+                new(0, top, left, _center.Height), new(right, top, ActualWidth - right, _center.Height)];
+            for (var i = 0; i < _clips.Length; i++)
+            {
+                var clip = new RectangleGeometry(clips[i]);
+                clip.Freeze();
+                _clips[i].Clip = clip;
+                using var drawing = _casters[i].RenderOpen();
+                drawing.DrawRectangle(brush, null, new Rect(0, 0,
+                    Math.Max(0, ActualWidth - 2 * ChromeMarginDip), Math.Max(0, ActualHeight - 2 * ChromeMarginDip)));
+            }
+            InvalidateVisual();
+        }
+
+        private static DropShadowEffect CreateEffect(Color color, double radius, double opacity, RenderingBias bias)
+        {
+            var effect = new DropShadowEffect { Color = color, BlurRadius = radius, Opacity = opacity,
+                ShadowDepth = 0, Direction = 0, RenderingBias = bias };
+            effect.Freeze();
+            return effect;
+        }
+
+        private static Brush CreateGlowBrush()
+        {
+            var brush = new SolidColorBrush(GlowColor);
+            brush.Freeze();
+            return brush;
+        }
+    }
 }

--- a/src/STranslate/Views/PinnedImageTranslateChromeWindow.cs
+++ b/src/STranslate/Views/PinnedImageTranslateChromeWindow.cs
@@ -1,0 +1,195 @@
+using STranslate.Helpers;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using DrawingRectangle = System.Drawing.Rectangle;
+
+namespace STranslate.Views;
+
+/// <summary>
+/// 为 Pinned 内容窗口绘制阴影与激活辉光的伴随窗。
+/// </summary>
+internal sealed class PinnedImageTranslateChromeWindow : Window
+{
+    // 为阴影与辉光预留的外围区域。
+    private const double ChromeMarginDip = 10;
+
+    private static readonly Color ActiveGlowColor = Color.FromRgb(0x4D, 0x90, 0xFE);
+
+    private readonly Border _shadowCaster;
+    private readonly Border _activeGlowCaster;
+    private bool _isActive;
+    private bool _isShadowEnabled = true;
+    private bool _sourceInitialized;
+    private bool _isClosed;
+    private bool _captureCloaked;
+
+    internal PinnedImageTranslateChromeWindow()
+    {
+        AllowsTransparency = true;
+        Background = Brushes.Transparent;
+        WindowStyle = WindowStyle.None;
+        ResizeMode = ResizeMode.NoResize;
+        ShowInTaskbar = true;
+        ShowActivated = false;
+        Focusable = false;
+        Topmost = true;
+
+        _shadowCaster = new Border
+        {
+            Margin = new Thickness(ChromeMarginDip),
+            Background = Brushes.White,
+            IsHitTestVisible = false,
+            Effect = new DropShadowEffect
+            {
+                BlurRadius = 8,
+                Direction = 0,
+                Opacity = 0.36,
+                ShadowDepth = 0,
+                RenderingBias = RenderingBias.Performance,
+                Color = Colors.Black,
+            },
+        };
+
+        var activeGlowBrush = new SolidColorBrush(ActiveGlowColor);
+        activeGlowBrush.Freeze();
+        _activeGlowCaster = new Border
+        {
+            Margin = new Thickness(ChromeMarginDip),
+            Background = activeGlowBrush,
+            IsHitTestVisible = false,
+            Visibility = Visibility.Collapsed,
+            Effect = new DropShadowEffect
+            {
+                BlurRadius = 6,
+                Direction = 0,
+                Opacity = 0.42,
+                ShadowDepth = 0,
+                RenderingBias = RenderingBias.Quality,
+                Color = ActiveGlowColor,
+            },
+        };
+
+        var root = new Grid { IsHitTestVisible = false };
+        root.Children.Add(_shadowCaster);
+        root.Children.Add(_activeGlowCaster);
+        Content = root;
+    }
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        _sourceInitialized = true;
+        Win32Helper.HideFromAltTab(this);
+        Win32Helper.ConfigureClickThroughNoActivate(this);
+        if (_captureCloaked && !Win32Helper.SetWindowCloaked(this, true))
+            throw new InvalidOperationException("Failed to cloak the pinned window chrome during capture.");
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _isClosed = true;
+        base.OnClosed(e);
+    }
+
+    internal void UpdateVisual(bool isActive, bool isShadowEnabled)
+    {
+        if (_isClosed)
+            return;
+
+        _isActive = isActive;
+        _isShadowEnabled = isShadowEnabled;
+        _activeGlowCaster.Visibility = _isActive ? Visibility.Visible : Visibility.Collapsed;
+        _shadowCaster.Visibility = !_isActive && _isShadowEnabled
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        UpdateVisibility();
+    }
+
+    internal void UpdateBounds(DrawingRectangle imageBounds, DpiScale dpi)
+    {
+        if (_isClosed || imageBounds.Width <= 0 || imageBounds.Height <= 0)
+            return;
+
+        var outer = CalculateOuterBounds(imageBounds, dpi);
+        var sx = Math.Max(0.01, dpi.DpiScaleX);
+        var sy = Math.Max(0.01, dpi.DpiScaleY);
+
+        Left = outer.Left / sx;
+        Top = outer.Top / sy;
+        Width = outer.Width / sx;
+        Height = outer.Height / sy;
+
+        Win32Helper.SetWindowPhysicalBounds(
+            this,
+            outer.Left,
+            outer.Top,
+            outer.Width,
+            outer.Height,
+            showWindow: false);
+
+        UpdateVisibility();
+    }
+
+    internal static DrawingRectangle CalculateOuterBounds(DrawingRectangle imageBounds, DpiScale dpi)
+    {
+        var sx = Math.Max(0.01, dpi.DpiScaleX);
+        var sy = Math.Max(0.01, dpi.DpiScaleY);
+        var marginX = Math.Max(1, (int)Math.Ceiling(ChromeMarginDip * sx));
+        var marginY = Math.Max(1, (int)Math.Ceiling(ChromeMarginDip * sy));
+        return DrawingRectangle.FromLTRB(
+            imageBounds.Left - marginX,
+            imageBounds.Top - marginY,
+            imageBounds.Right + marginX,
+            imageBounds.Bottom + marginY);
+    }
+
+    internal void EnsureShownBehind(Window contentWindow)
+    {
+        if (_isClosed || !ShouldBeVisible)
+            return;
+
+        if (!IsVisible)
+            Show();
+
+        Win32Helper.PlaceWindowBehind(this, contentWindow);
+    }
+
+    internal bool SetCloaked(bool cloaked)
+    {
+        _captureCloaked = cloaked;
+        return _isClosed || !_sourceInitialized || Win32Helper.SetWindowCloaked(this, cloaked);
+    }
+
+    internal void HideForOwnerClosing()
+    {
+        if (!_isClosed && IsVisible)
+            Hide();
+    }
+
+    internal void CloseSafely()
+    {
+        if (!_isClosed)
+            Close();
+    }
+
+    private bool ShouldBeVisible => _isActive || _isShadowEnabled;
+
+    private void UpdateVisibility()
+    {
+        if (_isClosed || !_sourceInitialized)
+            return;
+
+        if (ShouldBeVisible)
+        {
+            if (!IsVisible)
+                Show();
+        }
+        else if (IsVisible)
+        {
+            Hide();
+        }
+    }
+
+}

--- a/src/STranslate/Views/PinnedImageTranslateWindow.xaml
+++ b/src/STranslate/Views/PinnedImageTranslateWindow.xaml
@@ -1,0 +1,28 @@
+<Window
+    x:Class="STranslate.Views.PinnedImageTranslateWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:control="clr-namespace:STranslate.Controls"
+    Title="{DynamicResource ImageTranslate}"
+    Width="600"
+    Height="400"
+    MinWidth="1"
+    MinHeight="1"
+    AllowsTransparency="True"
+    Background="Transparent"
+    ResizeMode="NoResize"
+    Topmost="True"
+    WindowStartupLocation="Manual"
+    WindowStyle="None">
+    <Grid>
+        <Grid x:Name="PART_ImageSurface" Panel.ZIndex="5">
+            <control:ImageZoom
+                x:Name="PART_ImageZoom"
+                Panel.ZIndex="5"
+                AlwaysHideZoomValueHint="True"
+                DisableDoubleClickReset="True"
+                DisableAnimation="True"
+                IsPanAndZoomEnabled="False" />
+        </Grid>
+    </Grid>
+</Window>

--- a/src/STranslate/Views/PinnedImageTranslateWindow.xaml.cs
+++ b/src/STranslate/Views/PinnedImageTranslateWindow.xaml.cs
@@ -1,0 +1,373 @@
+using STranslate.Core;
+using STranslate.Helpers;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Windows.Win32;
+using DrawingPoint = System.Drawing.Point;
+using DrawingRectangle = System.Drawing.Rectangle;
+
+namespace STranslate.Views;
+
+/// <summary>静态贴图。只持有显示快照，图片物理矩形是窗口和辉光的共同布局依据。</summary>
+public partial class PinnedImageTranslateWindow
+{
+    private readonly PinnedWindowController _controller;
+    private readonly PinnedImageTranslateChromeWindow _chromeWindow;
+    private PinnedImageTranslateSnapshot? _snapshot;
+    private ObservableCollection<OcrWord> _originalWords = [];
+    private ObservableCollection<OcrWord> _translatedWords = [];
+    private HwndSource? _hwndSource;
+    private DrawingRectangle _imageBounds;
+    private DrawingPoint _dragStartCursor;
+    private DrawingRectangle _dragStartBounds;
+    private bool _potentialDrag;
+    private bool _isDragging;
+    private bool _showOriginal;
+    private bool _showShadow;
+    private bool _sourceInitialized;
+    private bool _isClosing;
+    private ContextMenu? _activeContextMenu;
+
+    public PinnedImageTranslateWindow(PinnedWindowController controller)
+    {
+        _controller = controller;
+        InitializeComponent();
+        _chromeWindow = new PinnedImageTranslateChromeWindow();
+    }
+
+    internal void Initialize(PinnedImageTranslateSnapshot snapshot, bool showShadow)
+    {
+        _snapshot = snapshot;
+        _showOriginal = snapshot.ShowOriginal;
+        _imageBounds = snapshot.PhysicalBounds;
+        _showShadow = showShadow;
+        _chromeWindow.UpdateVisual(false, showShadow);
+        _originalWords = new(snapshot.OriginalWords);
+        _translatedWords = new(snapshot.TranslatedWords);
+        ShowCurrentLayer();
+        ApplyBounds();
+    }
+
+    private void ShowCurrentLayer()
+    {
+        if (_snapshot is not { } snapshot)
+            return;
+        PART_ImageZoom.Source = _showOriginal ? snapshot.AnnotatedImage : snapshot.SourceImage;
+        PART_ImageZoom.OverlayDocument = _showOriginal ? null : snapshot.TranslationOverlay;
+        PART_ImageZoom.OcrWords = _showOriginal ? _originalWords : _translatedWords;
+    }
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        _sourceInitialized = true;
+        Win32Helper.HideFromAltTab(this);
+        _hwndSource = Win32Helper.AddWndProcHook(this, WndProc);
+        // 在任何 Chrome HWND 创建或显示之前设置截图状态。
+        _controller.OnWindowSourceInitialized(this);
+        ApplyBounds();
+    }
+
+    protected override void OnActivated(EventArgs e)
+    {
+        base.OnActivated(e);
+        UpdateChromeVisual();
+    }
+
+    protected override void OnDeactivated(EventArgs e)
+    {
+        base.OnDeactivated(e);
+        UpdateChromeVisual();
+    }
+
+    internal bool SetCaptureCloaked(bool cloaked)
+    {
+        var contentResult = !_sourceInitialized || Win32Helper.SetWindowCloaked(this, cloaked);
+        var chromeResult = _chromeWindow.SetCloaked(cloaked);
+        return contentResult && chromeResult;
+    }
+
+    internal void CloseTransientUiForCapture()
+    {
+        if (_activeContextMenu is { IsOpen: true })
+            _activeContextMenu.IsOpen = false;
+    }
+
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        base.OnPreviewMouseLeftButtonDown(e);
+        if (_isClosing)
+            return;
+        var point = e.GetPosition(PART_ImageZoom);
+        if (PART_ImageZoom.IsPointOverSelectableText(point))
+        {
+            if (e.ClickCount >= 2)
+            {
+                PART_ImageZoom.Focus();
+                PART_ImageZoom.SelectTextAtPoint(point, selectParagraph: e.ClickCount >= 3);
+                e.Handled = true;
+            }
+            return;
+        }
+        if (e.ClickCount >= 2)
+        {
+            e.Handled = true;
+            Close();
+            return;
+        }
+        PART_ImageZoom.ClearTextSelection();
+        Focus();
+        if (!TryGetCursorPosition(out _dragStartCursor))
+            return;
+        _dragStartBounds = _imageBounds;
+        _potentialDrag = true;
+        CaptureMouse();
+        e.Handled = true;
+    }
+
+    protected override void OnPreviewMouseMove(MouseEventArgs e)
+    {
+        base.OnPreviewMouseMove(e);
+        if (!_potentialDrag || e.LeftButton != MouseButtonState.Pressed ||
+            !TryGetCursorPosition(out var cursor))
+            return;
+        var dx = cursor.X - _dragStartCursor.X;
+        var dy = cursor.Y - _dragStartCursor.Y;
+        var dpi = GetDpi();
+        if (!_isDragging && Math.Abs(dx) < SystemParameters.MinimumHorizontalDragDistance * dpi.DpiScaleX &&
+            Math.Abs(dy) < SystemParameters.MinimumVerticalDragDistance * dpi.DpiScaleY)
+            return;
+        _isDragging = true;
+        MoveBy(_dragStartBounds.Left + dx - _imageBounds.Left,
+            _dragStartBounds.Top + dy - _imageBounds.Top, syncLogicalBounds: false);
+        e.Handled = true;
+    }
+
+    protected override void OnPreviewMouseLeftButtonUp(MouseButtonEventArgs e)
+    {
+        base.OnPreviewMouseLeftButtonUp(e);
+        if (!_potentialDrag)
+            return;
+        FinishDrag();
+        e.Handled = true;
+    }
+
+    protected override void OnLostMouseCapture(MouseEventArgs e)
+    {
+        base.OnLostMouseCapture(e);
+        if (_potentialDrag)
+            FinishDrag();
+    }
+
+    private void FinishDrag()
+    {
+        var moved = _isDragging;
+        _potentialDrag = _isDragging = false;
+        if (IsMouseCaptured)
+            ReleaseMouseCapture();
+        if (moved)
+            ApplyBounds();
+    }
+
+    protected override void OnPreviewMouseRightButtonUp(MouseButtonEventArgs e)
+    {
+        base.OnPreviewMouseRightButtonUp(e);
+        if (_isClosing)
+            return;
+        if (!PART_ImageZoom.IsPointOverTextSelection(e.GetPosition(PART_ImageZoom)))
+            PART_ImageZoom.ClearTextSelection();
+        OpenContextMenu();
+        e.Handled = true;
+    }
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (_isClosing || _activeContextMenu is { IsOpen: true })
+            return;
+        if (Keyboard.Modifiers == ModifierKeys.Control && e.Key is Key.A or Key.C)
+        {
+            if (e.Key == Key.A)
+                PART_ImageZoom.SelectAllText();
+            else
+                _controller.CopyText(PART_ImageZoom.SelectedText);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+        else if (e.Key == Key.Apps || (e.Key == Key.F10 && Keyboard.Modifiers == ModifierKeys.Shift))
+        {
+            OpenContextMenu();
+            e.Handled = true;
+        }
+        else if (Keyboard.Modifiers is ModifierKeys.None or ModifierKeys.Shift)
+        {
+            var step = Keyboard.Modifiers == ModifierKeys.Shift ? 10 : 1;
+            var (dx, dy) = e.Key switch
+            {
+                Key.Left => (-step, 0), Key.Right => (step, 0),
+                Key.Up => (0, -step), Key.Down => (0, step), _ => (0, 0),
+            };
+            if (dx == 0 && dy == 0)
+                return;
+            MoveBy(dx, dy, syncLogicalBounds: true);
+            e.Handled = true;
+        }
+    }
+
+    private void OpenContextMenu()
+    {
+        CloseTransientUiForCapture();
+        var menu = new ContextMenu { PlacementTarget = PART_ImageSurface };
+        AddItem("ImageTranslatePinnedCopyAll", () => _controller.CopyText(PART_ImageZoom.GetFullText()),
+            PART_ImageZoom.OcrWords is { Count: > 0 });
+        if (!string.IsNullOrEmpty(PART_ImageZoom.SelectedText))
+            AddItem("Copy", () => _controller.CopyText(PART_ImageZoom.SelectedText));
+        AddItem(_showOriginal ? "ImageTranslatePinnedShowTranslation" : "ImageTranslatePinnedShowOriginal", () =>
+        {
+            _showOriginal = !_showOriginal;
+            ShowCurrentLayer();
+        });
+        var shadow = AddItem("ImageTranslatePinnedWindowShadow", () =>
+        {
+            _showShadow = !_showShadow;
+            _controller.ShowShadow = _showShadow;
+            UpdateChromeVisual();
+        });
+        shadow.IsCheckable = true;
+        shadow.IsChecked = _showShadow;
+        AddItem("Close", Close);
+        menu.Closed += (_, _) =>
+        {
+            _activeContextMenu = null;
+            UpdateChromeVisual();
+        };
+        _activeContextMenu = menu;
+        menu.IsOpen = true;
+
+        MenuItem AddItem(string key, Action action, bool enabled = true)
+        {
+            var item = new MenuItem { IsEnabled = enabled };
+            item.SetResourceReference(HeaderedItemsControl.HeaderProperty, key);
+            item.Click += (_, _) => action();
+            menu.Items.Add(item);
+            return item;
+        }
+    }
+
+    private DpiScale GetDpi() => _sourceInitialized ? VisualTreeHelper.GetDpi(this) :
+        Win32Helper.GetDpiScaleForPhysicalPoint(_imageBounds.Left + _imageBounds.Width / 2,
+            _imageBounds.Top + _imageBounds.Height / 2);
+
+    private void ApplyBounds()
+    {
+        if (_isClosing || _imageBounds.IsEmpty)
+            return;
+        var dpi = GetDpi();
+        Left = _imageBounds.Left / dpi.DpiScaleX;
+        Top = _imageBounds.Top / dpi.DpiScaleY;
+        Width = PART_ImageSurface.Width = _imageBounds.Width / dpi.DpiScaleX;
+        Height = PART_ImageSurface.Height = _imageBounds.Height / dpi.DpiScaleY;
+        PART_ImageSurface.HorizontalAlignment = HorizontalAlignment.Left;
+        PART_ImageSurface.VerticalAlignment = VerticalAlignment.Top;
+        if (!_sourceInitialized)
+            return;
+        Win32Helper.SetWindowPhysicalBounds(this, _imageBounds.Left, _imageBounds.Top, _imageBounds.Width, _imageBounds.Height);
+        _chromeWindow.UpdateBounds(_imageBounds, dpi);
+        UpdateChromeVisual();
+    }
+
+    private void MoveBy(int dx, int dy, bool syncLogicalBounds)
+    {
+        if (dx == 0 && dy == 0)
+            return;
+        _imageBounds.Offset(dx, dy);
+        if (syncLogicalBounds)
+        {
+            ApplyBounds();
+            return;
+        }
+        var dpi = GetDpi();
+        if (!_chromeWindow.IsVisible || !Win32Helper.SetTwoWindowPhysicalBounds(this, _imageBounds,
+                _chromeWindow, PinnedImageTranslateChromeWindow.CalculateOuterBounds(_imageBounds, dpi)))
+        {
+            Win32Helper.SetWindowPhysicalBounds(this, _imageBounds.Left, _imageBounds.Top, _imageBounds.Width, _imageBounds.Height);
+            _chromeWindow.UpdateBounds(_imageBounds, dpi);
+        }
+    }
+
+    private void UpdateChromeVisual()
+    {
+        if (_isClosing || !_sourceInitialized)
+            return;
+        _chromeWindow.UpdateVisual(IsActive, _showShadow);
+        _chromeWindow.EnsureShownBehind(this);
+    }
+
+    private nint WndProc(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)
+    {
+        if (msg == 0x02E0) // WM_DPICHANGED：等 WPF 更新 DPI 后按原始物理尺寸重排。
+            Dispatcher.BeginInvoke(ApplyBounds, DispatcherPriority.Loaded);
+        else if (msg == 0x007E) // WM_DISPLAYCHANGE：拔掉显示器后，把不可见的贴图移回最近工作区。
+            Dispatcher.BeginInvoke(RestoreToVisibleMonitor, DispatcherPriority.Loaded);
+        return 0;
+    }
+
+    private void RestoreToVisibleMonitor()
+    {
+        if (_isClosing)
+            return;
+        var bounds = new Rect(_imageBounds.X, _imageBounds.Y, _imageBounds.Width, _imageBounds.Height);
+        if (MonitorInfo.GetDisplayMonitors().Any(monitor => monitor.WorkingArea.IntersectsWith(bounds)))
+            return;
+        var workArea = MonitorInfo.GetNearestDisplayMonitor(new WindowInteropHelper(this).Handle).WorkingArea;
+        _imageBounds = ClampToWorkArea(_imageBounds, workArea);
+        ApplyBounds();
+    }
+
+    internal static DrawingRectangle ClampToWorkArea(DrawingRectangle bounds, Rect workArea) => new(
+        (int)Math.Clamp(bounds.X, workArea.Left, Math.Max(workArea.Left, workArea.Right - bounds.Width)),
+        (int)Math.Clamp(bounds.Y, workArea.Top, Math.Max(workArea.Top, workArea.Bottom - bounds.Height)),
+        bounds.Width, bounds.Height);
+
+    private static bool TryGetCursorPosition(out DrawingPoint point)
+    {
+        if (PInvoke.GetCursorPos(out var cursor))
+        {
+            point = new(cursor.X, cursor.Y);
+            return true;
+        }
+        point = default;
+        return false;
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        _isClosing = true;
+        CloseTransientUiForCapture();
+        _chromeWindow.HideForOwnerClosing();
+        base.OnClosing(e);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _controller.Unregister(this);
+        if (_hwndSource != null)
+            _hwndSource.RemoveHook(WndProc);
+        _chromeWindow.CloseSafely();
+        _snapshot = null;
+        _originalWords.Clear();
+        _translatedWords.Clear();
+        ModernWindowLifecycle.Release(this, null);
+        base.OnClosed(e);
+    }
+}


### PR DESCRIPTION
Thank you very much for taking the time to review my contribution and explain your suggestions in detail. Your feedback helped me understand where I had made the implementation unnecessarily complicated and how to better fit the existing project. I've reworked it around the flow you suggested: complete screenshot capture, OCR and translation in Compact, then use **Pin** to keep the result in an independent, always-on-top window. I'd be grateful for any further guidance on anything that still needs improvement.

Changes addressing the feedback:

1. Keep the existing Standalone and Compact modes. Add a Pin button to the Compact toolbar and an optional Compact-only shortcut, **unassigned by default**, both using the same Pin command. Pin is available when a result is ready. The shortcut can be changed, cleared or reset under Settings → Hotkeys → OCR / image translation window, using the existing conflict checks and persistence. Pinning closes the current Compact window, and the existing entry points can start the next screenshot task. Pinned windows have no toolbar.
2. Store a static display snapshot in each pin. It shares the frozen images and completed translation overlay, and owns its text-selection data. OCR, translation and settings adjustments remain in Compact; pinned windows do not retain a translation ViewModel or rerun processing.
3. Support single-click/drag selection, double-click word selection, triple-click paragraph selection and copying in both text layers. Wrapped lines retain their paragraph membership, and clipped translations remain fully copyable. Right-clicking selected text provides Copy. The background menu contains Copy all, Original/Translation, Shadow and Close. Dragging the background moves the pin; double-clicking it closes the pin.
4. Allow multiple independent pins. Service or result-setting changes do not alter existing snapshots, while menu labels follow the application language. During screenshot selection, pinned content and shadows are temporarily hidden and restored on completion or cancellation, including pins created or closed during capture.
5. Display a black shadow and an active blue glow in a companion window with mouse passthrough. The shadow switch affects the current pin and saves the default for future pins; the active glow remains independent. Physical image bounds drive both windows, including movement across monitors with different DPI and recovery after a monitor is disconnected.

The implementation uses the existing WPF/MVVM and dependency-injection structure. The main-window dispatch, service manager and OCR plugin interfaces are unchanged. Pin extends the existing window-hotkey settings and binds to the toolbar command through WPF; it adds no global hotkey registration. `PinnedWindowController` manages pin lifetime and screenshot visibility; the existing screenshot methods acquire a hide/restore scope. The image-translation ViewModel exposes completed results and pin availability, with cancellation checks before publishing results. The content window reuses `ImageZoom`; selection helpers use paragraph membership from the existing layout analysis without changing segmentation rules, retain clipped text for copying, and clear stale selection when the text source changes. Settings gains one shadow-default value.

Static pins have no polling or background recomputation, and zoom animations are disabled. Shadow/glow effects are clipped to four edge regions, with the opaque center drawn directly. Drawing is rebuilt on size, DPI or activation changes; moving an unchanged pin reuses it.

Validation: Debug and Release builds succeed; Release completes with **zero warnings and errors**. The linked test code passes **326 regression tests**, and the submitted code passes all **274 existing upstream tests**. Rendering checks include **168 pixel comparisons** against the expected shadow/glow appearance across sizes, state changes and 100%–300% DPI. Basic functional checks and manual testing cover the screenshot/OCR/translation-to-pin flow, appearance, selection, copying and menus. Shortcut checks cover saved settings, defaults, clearing, resetting and conflicts. A compiled Compact-window test with a prepared result verifies live key bindings, rejection of unfinished results, and the shared Pin command for user-defined keys, including Ctrl+Alt+F8. Resetting leaves the shortcut unassigned, and the Pin button remains usable without a shortcut. Window-level checks cover screenshot hide/restore, creation and closure during capture, and release after closing; closed-window weak-reference counts are **0** for the 1-, 10- and 30-window groups.

See [Test code](https://github.com/Lne27/STranslate/tree/feature/pinned-static-review/src/Tests/STranslate.Tests) and [Performance tests and raw results](https://github.com/Lne27/STranslate/tree/feature/pinned-static-review/review/pinned-static).

Performance: snapshot creation averages **8.58 μs** over 1,000 iterations, with **12,032 bytes** of managed allocation per snapshot. The 30-window hide/restore median is **33.09 ms**, including two DWM synchronizations. Process CPU-time increments during three-second idle samples are **109.38 / 62.50 / 46.88 ms** for 1 / 10 / 30 windows. Creating and initializing the windows takes **152 ms** for one pin and **2.85 s** for a rapid batch of 30.

Measurements use Windows 11 build 26200, x64, .NET 10.0.11, 96 DPI and WPF Tier 2, with 800×400 BGRA source/annotated image pairs and 73 characters per text layer. Benchmark windows are shown off-screen. Component-memory measurements use 30 independent image pairs and pins, with three fresh processes per configuration after a one-window warm-up.

The component measurement adds images, text/snapshots, content windows and chrome in stages, ending with 29 shadows and one active glow. Each stage waits for Dispatcher idle, 500 ms and a full GC. The median total private-memory increment is **355.79 MiB**; its component breakdown is:

| Component stage | Private-memory increment | Share of total |
| --- | ---: | ---: |
| Source images | 26.77 MiB | 7.52% |
| Annotated images, translated text and snapshots | 33.68 MiB | 9.47% |
| Content windows, ImageZoom and WPF rendering | 244.02 MiB | 68.59% |
| Shadow and active-glow companion windows | 51.33 MiB | 14.43% |
| Total | **355.79 MiB** | **100%** |

Percentages are rounded. These process increments include rendering resources and runtime caches. The component measurement starts with image creation; actual pinning shares Compact's existing images. A separate measurement using the production controller to open 30 pins sequentially, allowing each to render while active, records a median total increment of **354.36 MiB** after a two-second wait and full GC. Content rendering retains ImageZoom's hardware rendering and transparent-image support.

Below is a screenshot from testing in a real usage scenario:

![Screenshot from testing Compact pinning in a real usage scenario](https://raw.githubusercontent.com/Lne27/STranslate/feature/pinned-static-review/review/pinned-static/test-image-1.png)