### PR TITLE
fix(i18n): localize the remaining user-facing hardcoded Chinese strings

### DIFF
--- a/src/STranslate/Core/ExternalCallService.cs
+++ b/src/STranslate/Core/ExternalCallService.cs
@@ -38,8 +38,8 @@ public class ExternalCallService(
         }
         catch (Exception ex)
         {
-            var msg = $"启动服务失败请重新配置端口: {prefix}";
-            logger.LogError(ex, msg);
+            logger.LogError(ex, "启动服务失败请重新配置端口: {Prefix}", prefix);
+            var msg = string.Format(i18n.GetTranslation("ExternalCallStartFailed"), prefix);
             OnActionOccurred?.Invoke(msg);
             notification.Show(i18n.GetTranslation("Prompt"), msg);
 

--- a/src/STranslate/Core/PluginManager.cs
+++ b/src/STranslate/Core/PluginManager.cs
@@ -333,22 +333,26 @@ public class PluginManager : IDisposable
 
     private PluginInstallResult CheckSamePluginVersion(PluginMetaData existingPlugin, PluginMetaData incomingPlugin)
     {
+        var i18n = Ioc.Default.GetRequiredService<Internationalization>();
+
         if (!Version.TryParse(incomingPlugin.Version, out var incomingVersion))
         {
-            var message = $"无法解析插件版本: {incomingPlugin.Version}";
-            _logger.LogTrace(message);
+            _logger.LogTrace("无法解析插件版本: {Version}", incomingPlugin.Version);
+            var message = string.Format(i18n.GetTranslation("PluginVersionParseFailed"), incomingPlugin.Version);
             return PluginInstallResult.Fail(message, existingPlugin);
         }
 
         if (Version.TryParse(existingPlugin.Version, out var installedVersion) && incomingVersion <= installedVersion)
         {
-            var message = $"插件版本过旧: {incomingPlugin.Name} v{incomingPlugin.Version}，当前已安装版本为 v{existingPlugin.Version}。";
-            _logger.LogTrace(message);
+            _logger.LogTrace("插件版本过旧: {Name} v{Version}，当前已安装版本为 v{InstalledVersion}。",
+                incomingPlugin.Name, incomingPlugin.Version, existingPlugin.Version);
+            var message = string.Format(i18n.GetTranslation("PluginVersionTooOld"), incomingPlugin.Name, incomingPlugin.Version,
+                existingPlugin.Version);
             return PluginInstallResult.Fail(message, existingPlugin);
         }
 
-        var upgradeMessage = $"可以选择升级到新版本(v{incomingPlugin.Version})。";
-        _logger.LogTrace(upgradeMessage);
+        _logger.LogTrace("可以选择升级到新版本(v{Version})。", incomingPlugin.Version);
+        var upgradeMessage = string.Format(i18n.GetTranslation("PluginUpgradeAvailable"), incomingPlugin.Version);
         return PluginInstallResult.RequiresUpgrade(upgradeMessage, incomingPlugin, existingPlugin);
     }
 

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -743,6 +743,11 @@
     <sys:String x:Key="BuiltIn">Built-in</sys:String>
     <sys:String x:Key="PreInstall">Pre-installed</sys:String>
     <sys:String x:Key="Extend">Extension</sys:String>
+    <sys:String x:Key="AddTranslationService">Add Translation Service</sys:String>
+    <sys:String x:Key="AddOcrService">Add OCR Service</sys:String>
+    <sys:String x:Key="AddTtsService">Add TTS Service</sys:String>
+    <sys:String x:Key="AddVocabularyService">Add Vocabulary Service</sys:String>
+    <sys:String x:Key="AddService">Add Service</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">Play Pronunciation</sys:String>

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -321,6 +321,7 @@
     <sys:String x:Key="ProxyTestSuccess">Connection successful! Current IP info: {0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">Connection failed, please check the proxy settings</sys:String>
     <sys:String x:Key="ProxyTestError">Test failed: {0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">Failed to start the service, please reconfigure the port: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Show Annotation</sys:String>
@@ -711,6 +712,9 @@
     <sys:String x:Key="SelectPluginFile">Select Plugin File</sys:String>
     <sys:String x:Key="PluginInstallFailed">Plugin installation failed</sys:String>
     <sys:String x:Key="PluginInstallSuccess">Plugin installation success</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">Unable to parse plugin version: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">Plugin version is too old: {0} v{1}, the installed version is v{2}.</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">You can upgrade to the new version (v{0}).</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">Developer: {0}&#10;Version: {1}&#10;Are you sure you want to delete the plugin "{2}"?</sys:String>
     <sys:String x:Key="PluginDeleteFailed">Failed to delete the plugin</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">The plugin has been marked for deletion. Restart to take effect.</sys:String>
@@ -748,6 +752,7 @@
     <sys:String x:Key="AddTtsService">Add TTS Service</sys:String>
     <sys:String x:Key="AddVocabularyService">Add Vocabulary Service</sys:String>
     <sys:String x:Key="AddService">Add Service</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">Dictionary services do not support the replace feature.</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">Play Pronunciation</sys:String>

--- a/src/STranslate/Languages/en.xaml
+++ b/src/STranslate/Languages/en.xaml
@@ -317,6 +317,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">Use semicolons (;) to separate multiple addresses, supports wildcards (*):&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">Effectiveness</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">Changes to proxy settings take effect after 2 minutes&#10;Apply immediately need restart</sys:String>
+    <sys:String x:Key="ProxyTesting">Testing connection...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">Connection successful! Current IP info: {0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">Connection failed, please check the proxy settings</sys:String>
+    <sys:String x:Key="ProxyTestError">Test failed: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Show Annotation</sys:String>

--- a/src/STranslate/Languages/fa.xaml
+++ b/src/STranslate/Languages/fa.xaml
@@ -755,6 +755,11 @@ localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="BuiltIn">داخلی</sys:String>
     <sys:String x:Key="PreInstall">پیش‌نصب‌شده</sys:String>
     <sys:String x:Key="Extend">افزونه‌ای</sys:String>
+    <sys:String x:Key="AddTranslationService">افزودن سرویس ترجمه</sys:String>
+    <sys:String x:Key="AddOcrService">افزودن سرویس OCR</sys:String>
+    <sys:String x:Key="AddTtsService">افزودن سرویس TTS</sys:String>
+    <sys:String x:Key="AddVocabularyService">افزودن سرویس جعبه واژگان</sys:String>
+    <sys:String x:Key="AddService">افزودن سرویس</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">پخش تلفظ</sys:String>

--- a/src/STranslate/Languages/fa.xaml
+++ b/src/STranslate/Languages/fa.xaml
@@ -328,6 +328,7 @@ localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="ProxyTestSuccess">اتصال موفق بود! اطلاعات IP فعلی: {0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">اتصال ناموفق بود، لطفاً تنظیمات پروکسی را بررسی کنید</sys:String>
     <sys:String x:Key="ProxyTestError">تست ناموفق بود: {0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">راه‌اندازی سرویس ناموفق بود، لطفاً پورت را دوباره پیکربندی کنید: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">نمایش نشانه‌گذاری</sys:String>
@@ -721,6 +722,9 @@ localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="SelectPluginFile">انتخاب فایل افزونه</sys:String>
     <sys:String x:Key="PluginInstallFailed">نصب افزونه ناموفق بود</sys:String>
     <sys:String x:Key="PluginInstallSuccess">افزونه با موفقیت نصب شد</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">تجزیه نسخه افزونه ناموفق بود: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">نسخه افزونه بسیار قدیمی است: {0} v{1}، نسخه نصب‌شده v{2} است.</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">می‌توانید به نسخه جدید (v{0}) ارتقا دهید.</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">سازنده: {0}
 نسخه: {1}
 آیا از حذف افزونه "{2}" اطمینان دارید؟</sys:String>
@@ -760,6 +764,7 @@ localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="AddTtsService">افزودن سرویس TTS</sys:String>
     <sys:String x:Key="AddVocabularyService">افزودن سرویس جعبه واژگان</sys:String>
     <sys:String x:Key="AddService">افزودن سرویس</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">سرویس‌های دیکشنری از قابلیت جایگزینی پشتیبانی نمی‌کنند.</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">پخش تلفظ</sys:String>

--- a/src/STranslate/Languages/fa.xaml
+++ b/src/STranslate/Languages/fa.xaml
@@ -324,6 +324,10 @@ localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">نحوه اعمال تغییرات</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">تغییرات تنظیمات پروکسی پس از ۲ دقیقه اعمال می‌شوند
 برای اعمال فوری، برنامه را دوباره راه‌اندازی کنید</sys:String>
+    <sys:String x:Key="ProxyTesting">در حال تست اتصال...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">اتصال موفق بود! اطلاعات IP فعلی: {0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">اتصال ناموفق بود، لطفاً تنظیمات پروکسی را بررسی کنید</sys:String>
+    <sys:String x:Key="ProxyTestError">تست ناموفق بود: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">نمایش نشانه‌گذاری</sys:String>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -310,6 +310,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">複数のアドレスはセミコロン(;)で区切ります。ワイルドカード(*)に対応：&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">反映について</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">プロキシ設定の変更は約2分後に反映されます&#10;即時反映させるには再起動が必要です</sys:String>
+    <sys:String x:Key="ProxyTesting">接続をテスト中...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">接続に成功しました！現在のIP情報：{0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">接続に失敗しました。プロキシ設定を確認してください</sys:String>
+    <sys:String x:Key="ProxyTestError">テストに失敗しました：{0}</sys:String>
 
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">検出結果を表示</sys:String>
     <sys:String x:Key="Standalone_OcrShowAnnotationDescription">元画像/検出結果画像の表示切替</sys:String>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -314,6 +314,7 @@
     <sys:String x:Key="ProxyTestSuccess">接続に成功しました！現在のIP情報：{0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">接続に失敗しました。プロキシ設定を確認してください</sys:String>
     <sys:String x:Key="ProxyTestError">テストに失敗しました：{0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">サービスの起動に失敗しました。ポートを設定し直してください: {0}</sys:String>
 
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">検出結果を表示</sys:String>
     <sys:String x:Key="Standalone_OcrShowAnnotationDescription">元画像/検出結果画像の表示切替</sys:String>
@@ -696,6 +697,9 @@
     <sys:String x:Key="SelectPluginFile">プラグインファイルを選択</sys:String>
     <sys:String x:Key="PluginInstallFailed">プラグインのインストールに失敗</sys:String>
     <sys:String x:Key="PluginInstallSuccess">プラグインのインストールに成功</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">プラグインのバージョンを解析できません: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">プラグインのバージョンが古すぎます: {0} v{1}、現在インストール済みのバージョンは v{2} です。</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">新しいバージョン (v{0}) にアップグレードできます。</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">開発者 {0}&#10;バージョン {1}&#10;プラグイン「{2}」を削除しますか？</sys:String>
     <sys:String x:Key="PluginDeleteFailed">プラグインの削除に失敗</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">プラグインは削除対象としてマークされました。再起動後に反映されます。</sys:String>
@@ -731,6 +735,7 @@
     <sys:String x:Key="AddTtsService">音声合成サービスを追加</sys:String>
     <sys:String x:Key="AddVocabularyService">単語帳サービスを追加</sys:String>
     <sys:String x:Key="AddService">サービスを追加</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">辞書サービスは置換機能に対応していません。</sys:String>
 
     <sys:String x:Key="PlayPronunciation">発音を再生</sys:String>
     <sys:String x:Key="Plural">複数形</sys:String>

--- a/src/STranslate/Languages/ja.xaml
+++ b/src/STranslate/Languages/ja.xaml
@@ -726,6 +726,11 @@
     <sys:String x:Key="BuiltIn">内蔵</sys:String>
     <sys:String x:Key="PreInstall">プリインストール</sys:String>
     <sys:String x:Key="Extend">拡張</sys:String>
+    <sys:String x:Key="AddTranslationService">翻訳サービスを追加</sys:String>
+    <sys:String x:Key="AddOcrService">文字認識サービスを追加</sys:String>
+    <sys:String x:Key="AddTtsService">音声合成サービスを追加</sys:String>
+    <sys:String x:Key="AddVocabularyService">単語帳サービスを追加</sys:String>
+    <sys:String x:Key="AddService">サービスを追加</sys:String>
 
     <sys:String x:Key="PlayPronunciation">発音を再生</sys:String>
     <sys:String x:Key="Plural">複数形</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -314,6 +314,7 @@
     <sys:String x:Key="ProxyTestSuccess">연결 성공! 현재 IP 정보: {0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">연결 실패, 프록시 설정을 확인하세요</sys:String>
     <sys:String x:Key="ProxyTestError">테스트 실패: {0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">서비스를 시작하지 못했습니다. 포트를 다시 설정하세요: {0}</sys:String>
 
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">텍스트 감지 결과 표시</sys:String>
     <sys:String x:Key="Standalone_OcrShowAnnotationDescription">원본 이미지/텍스트 감지 이미지 표시 전환</sys:String>
@@ -696,6 +697,9 @@
     <sys:String x:Key="SelectPluginFile">플러그인 파일 선택</sys:String>
     <sys:String x:Key="PluginInstallFailed">플러그인 설치 실패</sys:String>
     <sys:String x:Key="PluginInstallSuccess">플러그인 설치 성공</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">플러그인 버전을 해석할 수 없습니다: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">플러그인 버전이 너무 낮습니다: {0} v{1}, 현재 설치된 버전은 v{2}입니다.</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">새 버전(v{0})으로 업그레이드할 수 있습니다.</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">제작자 {0}&#10;버전 {1}&#10;플러그인 「{2}」을(를) 삭제하시겠습니까?</sys:String>
     <sys:String x:Key="PluginDeleteFailed">플러그인 삭제 실패</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">플러그인이 삭제 대상으로 표시되었습니다, 재시작 후 적용됩니다.</sys:String>
@@ -731,6 +735,7 @@
     <sys:String x:Key="AddTtsService">음성 합성 서비스 추가</sys:String>
     <sys:String x:Key="AddVocabularyService">단어장 서비스 추가</sys:String>
     <sys:String x:Key="AddService">서비스 추가</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">사전 서비스는 치환 기능을 지원하지 않습니다.</sys:String>
 
     <sys:String x:Key="PlayPronunciation">발음 재생</sys:String>
     <sys:String x:Key="Plural">복수형</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -310,6 +310,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">여러 주소는 세미콜론(;)으로 구분하며 와일드카드(*)를 지원합니다:&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">적용 설명</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">프록시 구성 수정은 약 2분 후 적용됩니다&#10;즉시 적용하려면 재시작이 필요합니다</sys:String>
+    <sys:String x:Key="ProxyTesting">연결 테스트 중...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">연결 성공! 현재 IP 정보: {0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">연결 실패, 프록시 설정을 확인하세요</sys:String>
+    <sys:String x:Key="ProxyTestError">테스트 실패: {0}</sys:String>
 
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">텍스트 감지 결과 표시</sys:String>
     <sys:String x:Key="Standalone_OcrShowAnnotationDescription">원본 이미지/텍스트 감지 이미지 표시 전환</sys:String>

--- a/src/STranslate/Languages/ko.xaml
+++ b/src/STranslate/Languages/ko.xaml
@@ -726,6 +726,11 @@
     <sys:String x:Key="BuiltIn">내장</sys:String>
     <sys:String x:Key="PreInstall">사전 설치</sys:String>
     <sys:String x:Key="Extend">확장</sys:String>
+    <sys:String x:Key="AddTranslationService">번역 서비스 추가</sys:String>
+    <sys:String x:Key="AddOcrService">텍스트 인식 서비스 추가</sys:String>
+    <sys:String x:Key="AddTtsService">음성 합성 서비스 추가</sys:String>
+    <sys:String x:Key="AddVocabularyService">단어장 서비스 추가</sys:String>
+    <sys:String x:Key="AddService">서비스 추가</sys:String>
 
     <sys:String x:Key="PlayPronunciation">발음 재생</sys:String>
     <sys:String x:Key="Plural">복수형</sys:String>

--- a/src/STranslate/Languages/ru.xaml
+++ b/src/STranslate/Languages/ru.xaml
@@ -321,6 +321,7 @@
     <sys:String x:Key="ProxyTestSuccess">Подключение установлено! Текущий IP: {0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">Не удалось подключиться, проверьте настройки прокси</sys:String>
     <sys:String x:Key="ProxyTestError">Ошибка проверки: {0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">Не удалось запустить сервис, задайте порт заново: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Показывать разметку</sys:String>
@@ -711,6 +712,9 @@
     <sys:String x:Key="SelectPluginFile">Выберите файл плагина</sys:String>
     <sys:String x:Key="PluginInstallFailed">Не удалось установить плагин</sys:String>
     <sys:String x:Key="PluginInstallSuccess">Плагин установлен</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">Не удалось определить версию плагина: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">Версия плагина устарела: {0} v{1}, установленная версия — v{2}.</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">Можно обновиться до новой версии (v{0}).</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">Разработчик: {0}&#10;Версия: {1}&#10;Удалить плагин «{2}»?</sys:String>
     <sys:String x:Key="PluginDeleteFailed">Не удалось удалить плагин</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">Плагин помечен для удаления. Изменения вступят в силу после перезапуска.</sys:String>
@@ -748,6 +752,7 @@
     <sys:String x:Key="AddTtsService">Добавить сервис озвучивания</sys:String>
     <sys:String x:Key="AddVocabularyService">Добавить сервис словаря</sys:String>
     <sys:String x:Key="AddService">Добавить сервис</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">Сервисы словарных статей не поддерживают перевод с заменой.</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">Прослушать произношение</sys:String>

--- a/src/STranslate/Languages/ru.xaml
+++ b/src/STranslate/Languages/ru.xaml
@@ -317,6 +317,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">Адреса разделяются точкой с запятой (;), поддерживаются подстановочные знаки (*):&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">Вступление в силу</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">Изменения настроек прокси вступают в силу в течение 2 минут&#10;Для немедленного применения нужен перезапуск</sys:String>
+    <sys:String x:Key="ProxyTesting">Идёт проверка подключения...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">Подключение установлено! Текущий IP: {0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">Не удалось подключиться, проверьте настройки прокси</sys:String>
+    <sys:String x:Key="ProxyTestError">Ошибка проверки: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Показывать разметку</sys:String>

--- a/src/STranslate/Languages/ru.xaml
+++ b/src/STranslate/Languages/ru.xaml
@@ -743,6 +743,11 @@
     <sys:String x:Key="BuiltIn">Встроенный</sys:String>
     <sys:String x:Key="PreInstall">Предустановленный</sys:String>
     <sys:String x:Key="Extend">Расширение</sys:String>
+    <sys:String x:Key="AddTranslationService">Добавить сервис перевода</sys:String>
+    <sys:String x:Key="AddOcrService">Добавить сервис распознавания текста</sys:String>
+    <sys:String x:Key="AddTtsService">Добавить сервис озвучивания</sys:String>
+    <sys:String x:Key="AddVocabularyService">Добавить сервис словаря</sys:String>
+    <sys:String x:Key="AddService">Добавить сервис</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">Прослушать произношение</sys:String>

--- a/src/STranslate/Languages/tr.xaml
+++ b/src/STranslate/Languages/tr.xaml
@@ -745,6 +745,11 @@
     <sys:String x:Key="BuiltIn">Yerleşik</sys:String>
     <sys:String x:Key="PreInstall">Ön Yüklü</sys:String>
     <sys:String x:Key="Extend">Eklenti</sys:String>
+    <sys:String x:Key="AddTranslationService">Çeviri Hizmeti Ekle</sys:String>
+    <sys:String x:Key="AddOcrService">OCR Hizmeti Ekle</sys:String>
+    <sys:String x:Key="AddTtsService">TTS Hizmeti Ekle</sys:String>
+    <sys:String x:Key="AddVocabularyService">Sözlük Hizmeti Ekle</sys:String>
+    <sys:String x:Key="AddService">Hizmet Ekle</sys:String>
 
     <!--  // Sözlük //  -->
     <sys:String x:Key="PlayPronunciation">Telaffuzu Çal</sys:String>

--- a/src/STranslate/Languages/tr.xaml
+++ b/src/STranslate/Languages/tr.xaml
@@ -322,6 +322,7 @@
     <sys:String x:Key="ProxyTestSuccess">Bağlantı başarılı! Geçerli IP bilgisi: {0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">Bağlantı başarısız, lütfen proxy ayarlarını kontrol edin</sys:String>
     <sys:String x:Key="ProxyTestError">Test başarısız: {0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">Hizmet başlatılamadı, lütfen bağlantı noktasını yeniden yapılandırın: {0}</sys:String>
 
     <!--  Bağımsız Sayfa  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Açıklamayı Göster</sys:String>
@@ -713,6 +714,9 @@
     <sys:String x:Key="SelectPluginFile">Eklenti Dosyası Seç</sys:String>
     <sys:String x:Key="PluginInstallFailed">Eklenti yüklemesi başarısız</sys:String>
     <sys:String x:Key="PluginInstallSuccess">Eklenti yüklemesi başarılı</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">Eklenti sürümü çözümlenemedi: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">Eklenti sürümü çok eski: {0} v{1}, yüklü sürüm v{2}.</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">Yeni sürüme (v{0}) yükseltebilirsiniz.</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">Geliştirici: {0}&#10;Sürüm: {1}&#10;"{2}" eklentisini silmek istediğinize emin misiniz?</sys:String>
     <sys:String x:Key="PluginDeleteFailed">Eklenti silinemedi</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">Eklenti silinmek üzere işaretlendi. Etkin olması için yeniden başlatın.</sys:String>
@@ -750,6 +754,7 @@
     <sys:String x:Key="AddTtsService">TTS Hizmeti Ekle</sys:String>
     <sys:String x:Key="AddVocabularyService">Sözlük Hizmeti Ekle</sys:String>
     <sys:String x:Key="AddService">Hizmet Ekle</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">Sözlük maddesi döndüren hizmetler değiştirerek çeviriyi desteklemez.</sys:String>
 
     <!--  // Sözlük //  -->
     <sys:String x:Key="PlayPronunciation">Telaffuzu Çal</sys:String>

--- a/src/STranslate/Languages/tr.xaml
+++ b/src/STranslate/Languages/tr.xaml
@@ -318,6 +318,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">Birden fazla adresi ayırmak için noktalı virgül (;) kullanın, joker karakterleri (*) destekler:&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">Etkinlik</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">Proxy ayarlarındaki değişiklikler 2 dakika sonra etkili olur&#10;Hemen uygulamak için yeniden başlatma gerekir</sys:String>
+    <sys:String x:Key="ProxyTesting">Bağlantı test ediliyor...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">Bağlantı başarılı! Geçerli IP bilgisi: {0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">Bağlantı başarısız, lütfen proxy ayarlarını kontrol edin</sys:String>
+    <sys:String x:Key="ProxyTestError">Test başarısız: {0}</sys:String>
 
     <!--  Bağımsız Sayfa  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">Açıklamayı Göster</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -744,6 +744,11 @@
     <sys:String x:Key="BuiltIn">内置</sys:String>
     <sys:String x:Key="PreInstall">预装</sys:String>
     <sys:String x:Key="Extend">拓展</sys:String>
+    <sys:String x:Key="AddTranslationService">添加翻译服务</sys:String>
+    <sys:String x:Key="AddOcrService">添加文本识别服务</sys:String>
+    <sys:String x:Key="AddTtsService">添加语音合成服务</sys:String>
+    <sys:String x:Key="AddVocabularyService">添加生词本服务</sys:String>
+    <sys:String x:Key="AddService">添加服务</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">播放发音</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -321,6 +321,7 @@
     <sys:String x:Key="ProxyTestSuccess">连接成功！当前IP信息：{0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">连接失败，请检查代理设置</sys:String>
     <sys:String x:Key="ProxyTestError">测试失败：{0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">启动服务失败请重新配置端口: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">显示文本检测结果</sys:String>
@@ -712,6 +713,9 @@
     <sys:String x:Key="SelectPluginFile">选择插件文件</sys:String>
     <sys:String x:Key="PluginInstallFailed">插件安装失败</sys:String>
     <sys:String x:Key="PluginInstallSuccess">插件安装成功</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">无法解析插件版本: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">插件版本过旧: {0} v{1}，当前已安装版本为 v{2}。</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">可以选择升级到新版本(v{0})。</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">开发者 {0}&#10;版本 {1}&#10;是否确认删除插件 「{2}」</sys:String>
     <sys:String x:Key="PluginDeleteFailed">插件删除失败</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">插件已标记删除，重启后生效</sys:String>
@@ -749,6 +753,7 @@
     <sys:String x:Key="AddTtsService">添加语音合成服务</sys:String>
     <sys:String x:Key="AddVocabularyService">添加生词本服务</sys:String>
     <sys:String x:Key="AddService">添加服务</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">词典服务不支持替换功能。</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">播放发音</sys:String>

--- a/src/STranslate/Languages/zh-cn.xaml
+++ b/src/STranslate/Languages/zh-cn.xaml
@@ -317,6 +317,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">使用分号(;)分隔多个地址，支持通配符(*)：&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">生效说明</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">修改代理配置需等待 2 分钟后生效&#10;立即生效需重启</sys:String>
+    <sys:String x:Key="ProxyTesting">正在测试连接...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">连接成功！当前IP信息：{0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">连接失败，请检查代理设置</sys:String>
+    <sys:String x:Key="ProxyTestError">测试失败：{0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">显示文本检测结果</sys:String>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -317,6 +317,10 @@
     <sys:String x:Key="Network_HelpBypassListContent" xml:space="preserve">使用分號(;)分隔多個地址，支持通配符(*)：&#10;localhost;127.*;10.*;192.168.*;*.example.com</sys:String>
     <sys:String x:Key="Network_HelpEffectiveness">生效說明</sys:String>
     <sys:String x:Key="Network_HelpEffectivenessContent" xml:space="preserve">修改代理配置需等待 2 分鐘後生效&#10;立即生效需重啟</sys:String>
+    <sys:String x:Key="ProxyTesting">正在測試連接...</sys:String>
+    <sys:String x:Key="ProxyTestSuccess">連接成功！當前IP資訊：{0}</sys:String>
+    <sys:String x:Key="ProxyTestFailed">連接失敗，請檢查代理設置</sys:String>
+    <sys:String x:Key="ProxyTestError">測試失敗：{0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">顯示文字偵測結果</sys:String>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -746,6 +746,11 @@
     <sys:String x:Key="BuiltIn">內建</sys:String>
     <sys:String x:Key="PreInstall">預裝</sys:String>
     <sys:String x:Key="Extend">擴展</sys:String>
+    <sys:String x:Key="AddTranslationService">新增翻譯服務</sys:String>
+    <sys:String x:Key="AddOcrService">新增文本識別服務</sys:String>
+    <sys:String x:Key="AddTtsService">新增語音合成服務</sys:String>
+    <sys:String x:Key="AddVocabularyService">新增生詞本服務</sys:String>
+    <sys:String x:Key="AddService">新增服務</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">播放發音</sys:String>

--- a/src/STranslate/Languages/zh-tw.xaml
+++ b/src/STranslate/Languages/zh-tw.xaml
@@ -321,6 +321,7 @@
     <sys:String x:Key="ProxyTestSuccess">連接成功！當前IP資訊：{0}</sys:String>
     <sys:String x:Key="ProxyTestFailed">連接失敗，請檢查代理設置</sys:String>
     <sys:String x:Key="ProxyTestError">測試失敗：{0}</sys:String>
+    <sys:String x:Key="ExternalCallStartFailed">啟動服務失敗，請重新設定端口: {0}</sys:String>
 
     <!--  Standalone Page  -->
     <sys:String x:Key="Standalone_OcrShowAnnotationHeader">顯示文字偵測結果</sys:String>
@@ -714,6 +715,9 @@
     <sys:String x:Key="SelectPluginFile">選擇外掛檔案</sys:String>
     <sys:String x:Key="PluginInstallFailed">外掛安裝失敗</sys:String>
     <sys:String x:Key="PluginInstallSuccess">插件安裝成功</sys:String>
+    <sys:String x:Key="PluginVersionParseFailed">無法解析外掛版本: {0}</sys:String>
+    <sys:String x:Key="PluginVersionTooOld">外掛版本過舊: {0} v{1}，目前已安裝版本為 v{2}。</sys:String>
+    <sys:String x:Key="PluginUpgradeAvailable">可以選擇升級到新版本(v{0})。</sys:String>
     <sys:String x:Key="PluginDeleteConfirm" xml:space="preserve">開發者：{0}&#10;版本：{1}&#10;是否確認刪除外掛「{2}」？</sys:String>
     <sys:String x:Key="PluginDeleteFailed">外掛刪除失敗</sys:String>
     <sys:String x:Key="PluginDeleteForRestart">外掛已標記刪除，重啟後生效</sys:String>
@@ -751,6 +755,7 @@
     <sys:String x:Key="AddTtsService">新增語音合成服務</sys:String>
     <sys:String x:Key="AddVocabularyService">新增生詞本服務</sys:String>
     <sys:String x:Key="AddService">新增服務</sys:String>
+    <sys:String x:Key="DictionaryServiceNotSupportReplace">詞典服務不支援替換功能。</sys:String>
 
     <!--  // Dictionary //  -->
     <sys:String x:Key="PlayPronunciation">播放發音</sys:String>

--- a/src/STranslate/Services/BaseService.cs
+++ b/src/STranslate/Services/BaseService.cs
@@ -59,15 +59,15 @@ public abstract partial class BaseService : ObservableObject, IDisposable
 
     public async Task<Service?> AddAsync()
     {
-        var title = ServiceType switch
+        var titleKey = ServiceType switch
         {
-            ServiceType.Translation => "添加翻译服务",
-            ServiceType.OCR => "添加文本识别服务",
-            ServiceType.TTS => "添加语音合成服务",
-            ServiceType.Vocabulary => "添加生词本服务",
-            _ => "添加服务"
+            ServiceType.Translation => "AddTranslationService",
+            ServiceType.OCR => "AddOcrService",
+            ServiceType.TTS => "AddTtsService",
+            ServiceType.Vocabulary => "AddVocabularyService",
+            _ => "AddService"
         };
-        var contentDialog = new ServiceContentDialog(title, Plugins);
+        var contentDialog = new ServiceContentDialog(_i18n.GetTranslation(titleKey), Plugins);
         if (await contentDialog.ShowAsync() == ContentDialogResult.Primary)
         {
             if (contentDialog.Result is PluginMetaData metaData)

--- a/src/STranslate/Services/TranslateService.cs
+++ b/src/STranslate/Services/TranslateService.cs
@@ -8,6 +8,7 @@ namespace STranslate.Services;
 public partial class TranslateService : BaseService
 {
     private readonly ServiceSettings _serviceSettings;
+    private readonly Internationalization _i18n;
 
     [ObservableProperty] public partial Service? ReplaceService { get; set; }
     [ObservableProperty] public partial Service? ImageTranslateService { get; set; }
@@ -23,6 +24,7 @@ public partial class TranslateService : BaseService
     ) : base(pluginManager, serviceManager, PluginService, serviceSettings, i18n)
     {
         _serviceSettings = serviceSettings;
+        _i18n = i18n;
 
         // Ensure all service data have translation options
         foreach (var item in SvcSettingDatas)
@@ -65,7 +67,8 @@ public partial class TranslateService : BaseService
     {
         if (svc.Plugin is IDictionaryPlugin)
         {
-            AppMessageBox.Show("词典服务不支持替换功能。", Constant.AppName, MessageBoxButton.OK, MessageBoxImage.Warning);
+            AppMessageBox.Show(_i18n.GetTranslation("DictionaryServiceNotSupportReplace"), Constant.AppName, MessageBoxButton.OK,
+                MessageBoxImage.Warning);
             return;
         }
 
@@ -86,7 +89,8 @@ public partial class TranslateService : BaseService
     {
         if (svc.Plugin is IDictionaryPlugin)
         {
-            AppMessageBox.Show("词典服务不支持替换功能。", Constant.AppName, MessageBoxButton.OK, MessageBoxImage.Warning);
+            AppMessageBox.Show(_i18n.GetTranslation("DictionaryServiceNotSupportReplace"), Constant.AppName, MessageBoxButton.OK,
+                MessageBoxImage.Warning);
             return;
         }
 

--- a/src/STranslate/ViewModels/Pages/NetworkViewModel.cs
+++ b/src/STranslate/ViewModels/Pages/NetworkViewModel.cs
@@ -9,6 +9,7 @@ namespace STranslate.ViewModels.Pages;
 public partial class NetworkViewModel : SearchViewModelBase
 {
     private readonly IHttpService _httpService;
+    private readonly Internationalization _i18n;
     private readonly ILogger<NetworkViewModel> _logger;
     private readonly ExternalCallService _externalCallService;
     private readonly Action<string> _externalActionHandler;
@@ -35,6 +36,7 @@ public partial class NetworkViewModel : SearchViewModelBase
         Settings = settings;
         DataProvider = dataProvider;
         _httpService = httpService;
+        _i18n = i18n;
         _logger = logger;
         _externalCallService = externalCallService;
 
@@ -48,7 +50,7 @@ public partial class NetworkViewModel : SearchViewModelBase
         if (IsTesting) return;
 
         IsTesting = true;
-        TestResult = "正在测试连接...";
+        TestResult = _i18n.GetTranslation("ProxyTesting");
 
         try
         {
@@ -56,16 +58,16 @@ public partial class NetworkViewModel : SearchViewModelBase
             if (isConnected)
             {
                 var ip = await _httpService.GetCurrentIpAsync();
-                TestResult = $"连接成功！当前IP信息：{ip}";
+                TestResult = string.Format(_i18n.GetTranslation("ProxyTestSuccess"), ip);
             }
             else
             {
-                TestResult = "连接失败，请检查代理设置";
+                TestResult = _i18n.GetTranslation("ProxyTestFailed");
             }
         }
         catch (Exception ex)
         {
-            TestResult = $"测试失败：{ex.Message}";
+            TestResult = string.Format(_i18n.GetTranslation("ProxyTestError"), ex.Message);
             _logger.LogError(ex, "代理连接测试失败");
         }
         finally

--- a/src/docs/i18n-internationalization.md
+++ b/src/docs/i18n-internationalization.md
@@ -209,7 +209,7 @@ internal static class AvailableLanguages
 - ❌ 无需重启提示：语言切换是热切换。
 
 ### 已知硬编码（待修复）
-- 暂无。设置页搜索框的「无结果」提示已改为 `NoResultsFound` key，走 i18n。
+- 暂无。设置页搜索框的「无结果」提示已改为 `NoResultsFound` key；网络页代理测试的四条结果提示已改为 `ProxyTesting` / `ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError` key，均走 i18n。
 
 ## 开发参考：在代码 / XAML 中使用国际化
 

--- a/src/docs/i18n-internationalization.md
+++ b/src/docs/i18n-internationalization.md
@@ -209,7 +209,11 @@ internal static class AvailableLanguages
 - ❌ 无需重启提示：语言切换是热切换。
 
 ### 已知硬编码（待修复）
-- 暂无。设置页搜索框的「无结果」提示已改为 `NoResultsFound` key；网络页代理测试的四条结果提示已改为 `ProxyTesting` / `ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError` key，均走 i18n。
+- 已修复：设置页搜索框的「无结果」提示已改为 `NoResultsFound` key；网络页代理测试的四条结果提示已改为 `ProxyTesting` / `ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError` key；服务添加对话框的标题已改为 `AddTranslationService` / `AddOcrService` / `AddTtsService` / `AddVocabularyService` / `AddService` key，均走 i18n。
+- 仍待修复（同类问题，文案都会直接呈现给用户）：
+  - `STranslate/Services/TranslateService.cs:68`、`:89` 的 `"词典服务不支持替换功能。"`，经 `AppMessageBox.Show` 弹窗显示；
+  - `STranslate/Core/PluginManager.cs:338`、`:345`、`:350` 的插件版本提示，经 `PluginInstallResult.Message` 进入 `PluginViewModel` 的 `ContentDialog.Content`；
+  - `STranslate/Core/ExternalCallService.cs:41` 的 `"启动服务失败请重新配置端口: {prefix}"`，经 `notification.Show` 显示（标题走 i18n，正文不走）。
 
 ## 开发参考：在代码 / XAML 中使用国际化
 

--- a/src/docs/i18n-internationalization.md
+++ b/src/docs/i18n-internationalization.md
@@ -209,11 +209,10 @@ internal static class AvailableLanguages
 - ❌ 无需重启提示：语言切换是热切换。
 
 ### 已知硬编码（待修复）
-- 已修复：设置页搜索框的「无结果」提示已改为 `NoResultsFound` key；网络页代理测试的四条结果提示已改为 `ProxyTesting` / `ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError` key；服务添加对话框的标题已改为 `AddTranslationService` / `AddOcrService` / `AddTtsService` / `AddVocabularyService` / `AddService` key，均走 i18n。
-- 仍待修复（同类问题，文案都会直接呈现给用户）：
-  - `STranslate/Services/TranslateService.cs:68`、`:89` 的 `"词典服务不支持替换功能。"`，经 `AppMessageBox.Show` 弹窗显示；
-  - `STranslate/Core/PluginManager.cs:338`、`:345`、`:350` 的插件版本提示，经 `PluginInstallResult.Message` 进入 `PluginViewModel` 的 `ContentDialog.Content`；
-  - `STranslate/Core/ExternalCallService.cs:41` 的 `"启动服务失败请重新配置端口: {prefix}"`，经 `notification.Show` 显示（标题走 i18n，正文不走）。
+- 已修复（均走 i18n，对应日志保持中文）：设置页搜索框的「无结果」提示 `NoResultsFound`；网络页代理测试的四条结果提示 `ProxyTesting` / `ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError`；服务添加对话框的标题 `AddTranslationService` / `AddOcrService` / `AddTtsService` / `AddVocabularyService` / `AddService`；词典服务不支持替换的提示 `DictionaryServiceNotSupportReplace`；插件版本校验的三条提示 `PluginVersionParseFailed` / `PluginVersionTooOld` / `PluginUpgradeAvailable`；外部调用服务启动失败的提示 `ExternalCallStartFailed`。
+- 仍待处理（本 PR 未涉及，需先定方案）：
+  - 抛给用户的异常文案基本都是中文。`ex.Message` 会被直接拼进 Snackbar 或对话框，共 11 处：`ViewModels/MainWindowViewModel.cs:1218`、`:1369`，`ViewModels/ImageTranslateWindowViewModel.cs:281`、`:387`、`:440`，`ViewModels/OcrWindowViewModel.cs:200`、`:322`、`:363`，`ViewModels/Pages/HistoryViewModel.cs:288`，`ViewModels/Pages/PluginViewModel.cs:349`、`:605`。因此 `Helpers/LanguageDetector.cs`、`Core/AudioReaderFactory.cs` 以及各插件里的 `throw new Exception("请求结果为空")` 之类都会原样呈现给用户；改动面涉及大量调用点和插件语言文件，宜另开 PR。
+  - `Helpers/HistoryCsvHelper.cs` 的历史记录 CSV 导出：表头（`:37` 起）以及写进单元格的 `回译:`（`:128`）、`词条:`（`:141`）、`释义:`（`:145`）、`例句:`（`:152`）和分隔符 `；`（`:163`）均为中文。它属于导出文件格式而非界面文案，跟随界面语言会影响既有文件的解析，需要先定方案。
 
 ## 开发参考：在代码 / XAML 中使用国际化
 


### PR DESCRIPTION
## English

### What

Three groups of hardcoded Chinese strings that reach the user in **every** UI
language, English included. Found while translating the app to Russian: the
surrounding pages are localized, these particular strings are not, which makes
them stand out immediately.

Each group is a separate commit, so they can be reviewed one at a time. They do build on
each other, though: the second and third add their keys next to the first one's, so please
take them in order rather than cherry-picking the middle one.

### 1. Proxy connection test results

**Settings → Network → Test Connection.** Four result messages hardcoded in
`ViewModels/Pages/NetworkViewModel.cs`.

```diff
-        TestResult = "正在测试连接...";
+        TestResult = _i18n.GetTranslation("ProxyTesting");
...
-                TestResult = $"连接成功！当前IP信息：{ip}";
+                TestResult = string.Format(_i18n.GetTranslation("ProxyTestSuccess"), ip);
...
-                TestResult = "连接失败，请检查代理设置";
+                TestResult = _i18n.GetTranslation("ProxyTestFailed");
...
-            TestResult = $"测试失败：{ex.Message}";
+            TestResult = string.Format(_i18n.GetTranslation("ProxyTestError"), ex.Message);
```

`NetworkViewModel` already receives `Internationalization` (it passes it to
`SearchViewModelBase`), so only a field was added — no DI change.

The four keys deliberately have **no** `Network_` prefix:
`SearchViewModelBase.UpdateItems` puts every `Network_*` value into the settings
search suggestions, where transient status messages do not belong. This follows
the existing convention for runtime messages (`BackupSuccess`, `DownloadFailed`,
…), which are also unprefixed.

### 2. Service picker dialog titles

`Services/BaseService.cs` builds the title of the service picker dialog from
Chinese literals in `AddAsync()`, so all four pickers — translation, OCR, TTS,
vocabulary — keep a Chinese heading in every UI language. Everything else in
that dialog already goes through `DynamicResource`, which is exactly why the
untranslated title stands out.

```diff
-        var title = ServiceType switch
+        var titleKey = ServiceType switch
         {
-            ServiceType.Translation => "添加翻译服务",
-            ServiceType.OCR => "添加文本识别服务",
-            ServiceType.TTS => "添加语音合成服务",
-            ServiceType.Vocabulary => "添加生词本服务",
-            _ => "添加服务"
+            ServiceType.Translation => "AddTranslationService",
+            ServiceType.OCR => "AddOcrService",
+            ServiceType.TTS => "AddTtsService",
+            ServiceType.Vocabulary => "AddVocabularyService",
+            _ => "AddService"
         };
-        var contentDialog = new ServiceContentDialog(title, Plugins);
+        var contentDialog = new ServiceContentDialog(_i18n.GetTranslation(titleKey), Plugins);
```

`BaseService` already holds an `Internationalization` field (`DeleteAsync` uses
it), so again no DI change. Every language follows the wording that dictionary
already uses for the service types: the English titles line up with
`WelcomeSetup_TranslateServices` / `WelcomeSetup_OcrServices` and the
`*ServiceNotFound*` messages (which say "OCR Service" and "TTS", not the bare
`Ocr` / `Tts` of the navigation entries), the other languages with their own
`Translate` / `Ocr` / `Tts` / `Vocabulary` values.

### 3. The remaining five

Going through the channels the app actually talks to the user with —
`AppMessageBox.Show`, `Snackbar`, `ContentDialog`, `notification.Show` — turned
up five more:

- `Services/TranslateService.cs:68` and `:89` — "词典服务不支持替换功能。", shown
  as a warning box when a dictionary service is picked for replace translation
  or image translation;
- `Core/PluginManager.cs:338`, `:345`, `:350` — the three plugin version
  messages. Two of them are returned through `PluginInstallResult.Fail()`, and
  `PluginViewModel` puts `Message` straight into `ContentDialog.Content` when
  installing a `.spkg`. The third one accompanies `UpgradeRequired`, where the
  dialog is built from `PluginUpgradeConfirm` instead, so today it only reaches
  the log; it is translated anyway because all three come from the same method
  and the same result contract, and leaving one of them Chinese would be
  arbitrary;
- `Core/ExternalCallService.cs:41` — the start failure message, shown both as a
  notification and on **Settings → Network** under the
  `Network_ExternalCallPortError` card.

`PluginManager` resolves `Internationalization` through `Ioc.Default`, the way
it already does in `LoadPluginLanguageResources`. That is not a shortcut:
`Internationalization` takes `PluginManager` as a constructor dependency, so
injecting it the other way round would create a cycle in the DI container.

`TranslateService` gets its own `Internationalization` field: the one in
`BaseService` is `private`, and widening it to `protected` looked like a bigger
change than adding the field — happy to do it the other way if you prefer.

### Persian

`fa.xaml` landed in `main` (#765) after this branch was first written, so the
fourteen keys are in it too — worded from the terms `fa.xaml` already uses:
`سرویس ترجمه`, `سرویس OCR`, `سرویس TTS`, `سرویس جعبه واژگان` for the service
types, `ناموفق بود` for failures, `ارتقا` for the upgrade wording. I do not
speak Persian, so @amir1376 — please correct anything that reads wrong; I would
rather have the values reviewed than leave the dictionary 14 keys short of the
other seven.

### The Chinese text does not change

For all fourteen keys the `zh-cn` value is the original string verbatim, so
nothing changes for Chinese users. The log lines next to them stay Chinese as
well — logs are Chinese throughout the codebase and are not user-facing. They
are now structured (`LogTrace("插件版本过旧: {Name} v{Version}…", …)`) instead of
interpolated, so the log keeps its wording while the dialog follows the UI
language. That also removes a latent bug: `LogTrace()` used to receive an
already-interpolated string as its message template, so a plugin name or
version containing braces would have been parsed as a property name.

### Deliberately left alone

Both are now written down in the doc's known-hardcoding section instead:

- exception texts. `MainWindowViewModel.cs:1218` and `:1369` — and nine more
  places — append `ex.Message` to a snackbar or a dialog, so Chinese
  `throw new Exception("请求结果为空")` in `LanguageDetector`,
  `AudioReaderFactory` and inside plugins reaches the user as is. Fixing that
  touches a lot of call sites and plugin dictionaries, and deserves its own PR;
- `Helpers/HistoryCsvHelper.cs` — the Chinese column headers of the history CSV
  export, plus the Chinese labels written into the cells. That is an export file
  format rather than UI text: following the UI language would change files that
  people already parse, so it needs a decision first.

### Files

```text
 src/STranslate/Languages/{en,zh-cn,zh-tw,ja,ko,tr,ru,fa}.xaml | +14 keys each
 src/STranslate/ViewModels/Pages/NetworkViewModel.cs        | 6 lines changed, 1 field added
 src/STranslate/Services/BaseService.cs                     | 7 lines changed
 src/STranslate/Services/TranslateService.cs                | +6 / -2, 1 field added
 src/STranslate/Core/PluginManager.cs                       | +10 / -6
 src/STranslate/Core/ExternalCallService.cs                 | +2 / -2
 src/docs/i18n-internationalization.md                      | known-hardcoding section updated
```

### Verification

Windows 10 x64, .NET 10 SDK 10.0.400: `dotnet build src/STranslate.slnx -c Release`
— 0 errors, `dotnet test` — 259/259 passing. All eight dictionaries carry the same
783 keys, and every placeholder (`{0}`–`{2}`) matches across them. All four dialogs, the proxy test and
the plugin install path exercised by hand in Russian, English and 简体中文.

---

## 中文

### 内容

三组会在**任何**界面语言（包括英文）下直接呈现给用户的中文硬编码。是在把程序翻译成
俄语时发现的：周围的页面都已本地化，唯独这些字符串不是，所以格外扎眼。三组各自一个
提交，便于逐条审阅。三个提交彼此有先后依赖（后两个的 key 就加在前一个的旁边），请按顺序
合入，不宜单独摘取中间的提交。

### 1. 代理连接测试结果

**设置 → 网络 → 测试连接** 的四条结果提示直接硬编码在
`ViewModels/Pages/NetworkViewModel.cs` 里，现改为 `ProxyTesting` /
`ProxyTestSuccess` / `ProxyTestFailed` / `ProxyTestError` 四个 key。
`NetworkViewModel` 本来就接收 `Internationalization`（传给 `SearchViewModelBase`），
只新增了一个字段，无需改 DI。

四个 key 特意不加 `Network_` 前缀：`SearchViewModelBase.UpdateItems` 会把所有
`Network_*` 的值收进设置页搜索建议里，运行时状态提示不该出现在那里——这也与既有的
`BackupSuccess` / `DownloadFailed` 等运行时消息不加页面前缀的写法一致。

### 2. 服务添加对话框标题

`Services/BaseService.cs` 的 `AddAsync()` 用中文字面量拼出对话框标题，因此文本翻译 /
文本识别 / 语音合成 / 生词本四个对话框在任何界面语言下标题都是中文，而对话框其余部分
早已走 `DynamicResource`。现改为 `AddTranslationService` / `AddOcrService` /
`AddTtsService` / `AddVocabularyService` / `AddService` 五个 key。
`BaseService` 本来就持有 `Internationalization` 字段（`DeleteAsync` 在用），无需改 DI。
各语言的措辞沿用各自语言文件里既有的服务类型说法：英文与
`WelcomeSetup_TranslateServices` / `WelcomeSetup_OcrServices` 以及 `*ServiceNotFound*`
提示一致（它们写作「OCR Service」「TTS」，而非导航项里的 `Ocr` / `Tts`）。

### 3. 其余五处

沿着同一思路，把程序与用户对话的几个出口（`AppMessageBox.Show`、`Snackbar`、
`ContentDialog`、`notification.Show`）逐一过了一遍，又找到五处：

- `Services/TranslateService.cs:68`、`:89` 的「词典服务不支持替换功能。」，在把词典服务
  设为替换翻译或图片翻译时以警告框弹出；
- `Core/PluginManager.cs:338`、`:345`、`:350` 的三条插件版本提示。其中两条经
  `PluginInstallResult.Fail()` 返回，安装 `.spkg` 时由 `PluginViewModel` 直接把
  `Message` 放进 `ContentDialog.Content`；第三条随 `UpgradeRequired` 返回，而该分支的
  对话框由 `PluginUpgradeConfirm` 拼出，因此目前只进日志。仍一并改为 key：三条出自同一个
  方法、同一个结果契约，单独留一条中文并无道理；
- `Core/ExternalCallService.cs:41` 的启动失败提示，既作通知弹出，也显示在
  **设置 → 网络** 的 `Network_ExternalCallPortError` 卡片下。

`PluginManager` 通过 `Ioc.Default` 取 `Internationalization`，与它在
`LoadPluginLanguageResources` 中的既有写法一致。这不是图省事：`Internationalization`
的构造函数依赖 `PluginManager`，反向注入会在 DI 容器里形成循环。
`TranslateService` 自己新增了一个 `Internationalization` 字段，因为 `BaseService` 里的
那个是 `private`；把它放宽为 `protected` 改动更大，如果您更倾向那样，我可以改。

### 波斯语

`fa.xaml` 是本分支写好之后才随 #765 进入 `main` 的，因此这十四个 key 也一并补上了，措辞沿用
`fa.xaml` 自己既有的说法：服务类型用 `سرویس ترجمه` / `سرویس OCR` / `سرویس TTS` /
`سرویس جعبه واژگان`，失败用 `ناموفق بود`，升级用 `ارتقا`。我不懂波斯语，所以请 @amir1376
帮忙校对；比起让波斯语比其余七种语言少 14 个 key，我更希望这些取值得到审阅。

### 中文文案不变

十四个 key 的 `zh-cn` 取值与原字符串完全一致，中文用户看到的文案不变。旁边的日志同样
保持中文（日志全仓库都是中文，不面向用户），只是从字符串插值改为结构化模板
（`LogTrace("插件版本过旧: {Name} v{Version}…", …)`）：措辞不变，对话框跟随界面语言。
顺带消除一个潜在问题——原先 `LogTrace()` 收到的是已插值的字符串作为消息模板，插件名或
版本号里若含花括号会被当成属性名解析。

### 刻意未动的两处

已写入文档的「已知硬编码」一节：

- 抛给用户的异常文案。`ViewModels/MainWindowViewModel.cs:1218`、`:1369` 等共 11 处会把
  `ex.Message` 直接拼进 Snackbar 或对话框，因此 `Helpers/LanguageDetector.cs`、
  `Core/AudioReaderFactory.cs` 以及各插件里的 `throw new Exception("请求结果为空")`
  之类都会原样呈现给用户；改动面涉及大量调用点和插件语言文件，宜另开 PR；
- `Helpers/HistoryCsvHelper.cs` 的历史记录 CSV 导出：表头以及写进单元格的
  「回译:」「词条:」「释义:」「例句:」和分隔符「；」。它属于导出文件格式而非界面文案，
  跟随界面语言会影响既有文件的解析，需要先定方案。

### 验证结果

Windows 10 x64、.NET 10 SDK 10.0.400：`dotnet build src/STranslate.slnx -c Release`
0 错误，`dotnet test` 259/259 通过。八个语言文件的 key 集合完全一致（各 783 个），
占位符 `{0}`–`{2}` 逐一对齐。四个对话框、代理测试与插件安装路径均已在俄语、英语
和简体中文界面下手工走查。
