### PR TITLE
fix: 修复默认 Edge TTS 服务缺少 Origin 导致的 403

### DIFF
--- a/src/Plugins/STranslate.Plugin.Tts.MicrosoftEdge/Main.cs
+++ b/src/Plugins/STranslate.Plugin.Tts.MicrosoftEdge/Main.cs
@@ -36,7 +36,22 @@ public class Main : ITtsPlugin
             pitch = Settings.Pitch.ToString(),
             style = Settings.Style
         };
-        var response = await Context.HttpService.PostAsBytesAsync(Settings.Url, content, cancellationToken: cancellationToken);
+        Options? options = null;
+        if (Uri.TryCreate(Settings.Url, UriKind.Absolute, out var uri)
+            && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(uri.Host, "tts.wangwangit.com", StringComparison.OrdinalIgnoreCase)
+            && uri.Port == 443)
+        {
+            options = new Options
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    ["Origin"] = "https://tts.wangwangit.com"
+                }
+            };
+        }
+
+        var response = await Context.HttpService.PostAsBytesAsync(Settings.Url, content, options, cancellationToken);
         await Context.AudioPlayer.PlayAsync(response, cancellationToken);
     }
 }

--- a/src/Plugins/STranslate.Plugin.Tts.MicrosoftEdge/plugin.json
+++ b/src/Plugins/STranslate.Plugin.Tts.MicrosoftEdge/plugin.json
@@ -3,7 +3,7 @@
   "Name": "Edge TTS",
   "Description": "Microsoft Edge Text-to-Speech plugin for STranslate",
   "Author": "zggsong",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Website": "https://github.com/ZGGSONG/STranslate",
   "ExecuteFileName": "STranslate.Plugin.Tts.MicrosoftEdge.dll",
   "IconPath": "icon.png"

--- a/src/Tests/STranslate.Tests/MicrosoftEdgeTtsPluginTests.cs
+++ b/src/Tests/STranslate.Tests/MicrosoftEdgeTtsPluginTests.cs
@@ -1,0 +1,249 @@
+using STranslate.Plugin;
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using EdgeMain = STranslate.Plugin.Tts.MicrosoftEdge.Main;
+using EdgeSettings = STranslate.Plugin.Tts.MicrosoftEdge.Settings;
+
+namespace STranslate.Tests;
+
+public class MicrosoftEdgeTtsPluginTests
+{
+    private const string ExpectedOrigin = "https://tts.wangwangit.com";
+
+    [Theory]
+    [InlineData("https://tts.wangwangit.com/v1/audio/speech")]
+    [InlineData("https://TTS.WANGWANGIT.COM/v1/audio/speech")]
+    [InlineData("https://tts.wangwangit.com:443/v1/audio/speech")]
+    public async Task PlayAudioAsync_TargetHttpsEndpoint_AddsOnlyExpectedOrigin(string url)
+    {
+        var harness = CreateHarness(new EdgeSettings { Url = url });
+
+        await harness.Plugin.PlayAudioAsync("你好");
+
+        var call = Assert.Single(harness.Http.Calls);
+        var headers = Assert.IsType<Dictionary<string, string>>(call.Options?.Headers);
+        var header = Assert.Single(headers);
+        Assert.Equal("Origin", header.Key);
+        Assert.Equal(ExpectedOrigin, header.Value);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/v1/audio/speech")]
+    [InlineData("https://tts.wangwangit.com.example.com/v1/audio/speech")]
+    [InlineData("https://prefix-tts.wangwangit.com/v1/audio/speech")]
+    [InlineData("http://tts.wangwangit.com/v1/audio/speech")]
+    [InlineData("https://tts.wangwangit.com:444/v1/audio/speech")]
+    [InlineData("/v1/audio/speech")]
+    [InlineData("not a valid URL")]
+    public async Task PlayAudioAsync_OtherUrl_ForwardsWithoutOrigin(string url)
+    {
+        var harness = CreateHarness(new EdgeSettings { Url = url });
+
+        await harness.Plugin.PlayAudioAsync("你好");
+
+        var call = Assert.Single(harness.Http.Calls);
+        Assert.Equal(url, call.Url);
+        AssertNoOrigin(call.Options);
+    }
+
+    [Fact]
+    public async Task PlayAudioAsync_UrlChanges_CreatesIndependentRequestOptionsWithoutReusingOrigin()
+    {
+        var settings = new EdgeSettings();
+        var harness = CreateHarness(settings);
+
+        await harness.Plugin.PlayAudioAsync("first");
+        await harness.Plugin.PlayAudioAsync("second");
+        settings.Url = "https://example.com/v1/audio/speech";
+        await harness.Plugin.PlayAudioAsync("third");
+
+        Assert.Equal(3, harness.Http.Calls.Count);
+        var firstOptions = Assert.IsType<Options>(harness.Http.Calls[0].Options);
+        var secondOptions = Assert.IsType<Options>(harness.Http.Calls[1].Options);
+        Assert.NotSame(firstOptions, secondOptions);
+        Assert.Equal(ExpectedOrigin, Assert.IsType<Dictionary<string, string>>(firstOptions.Headers)["Origin"]);
+        Assert.Equal(ExpectedOrigin, Assert.IsType<Dictionary<string, string>>(secondOptions.Headers)["Origin"]);
+        AssertNoOrigin(harness.Http.Calls[2].Options);
+    }
+
+    [Fact]
+    public async Task PlayAudioAsync_Success_ForwardsPayloadAudioAndCancellationToken()
+    {
+        byte[] response = [0x49, 0x44, 0x33, 0x04];
+        var settings = new EdgeSettings
+        {
+            Voice = "en-US-JennyNeural",
+            Speed = 1.25,
+            Pitch = -7,
+            Style = "cheerful"
+        };
+        var harness = CreateHarness(settings, (_, _) => Task.FromResult(response));
+        using var cancellation = new CancellationTokenSource();
+
+        await harness.Plugin.PlayAudioAsync("hello", cancellation.Token);
+
+        var call = Assert.Single(harness.Http.Calls);
+        Assert.Equal(cancellation.Token, call.CancellationToken);
+        using var payload = JsonDocument.Parse(JsonSerializer.Serialize(call.Content));
+        var properties = payload.RootElement.EnumerateObject().ToArray();
+        Assert.Equal(["input", "voice", "speed", "pitch", "style"], properties.Select(property => property.Name));
+        Assert.Equal(JsonValueKind.String, properties[0].Value.ValueKind);
+        Assert.Equal("hello", properties[0].Value.GetString());
+        Assert.Equal(JsonValueKind.String, properties[1].Value.ValueKind);
+        Assert.Equal("en-US-JennyNeural", properties[1].Value.GetString());
+        Assert.Equal(JsonValueKind.Number, properties[2].Value.ValueKind);
+        Assert.Equal(1.25, properties[2].Value.GetDouble());
+        Assert.Equal(JsonValueKind.String, properties[3].Value.ValueKind);
+        Assert.Equal("-7", properties[3].Value.GetString());
+        Assert.Equal(JsonValueKind.String, properties[4].Value.ValueKind);
+        Assert.Equal("cheerful", properties[4].Value.GetString());
+
+        var playback = Assert.Single(harness.Audio.Calls);
+        Assert.Same(response, playback.AudioData);
+        Assert.Equal(cancellation.Token, playback.CancellationToken);
+    }
+
+    [Fact]
+    public async Task PlayAudioAsync_HttpFailure_PropagatesExceptionWithoutPlaybackOrRetry()
+    {
+        var expected = new HttpRequestException("TTS unavailable", null, HttpStatusCode.Forbidden);
+        var harness = CreateHarness(
+            new EdgeSettings(),
+            (_, _) => Task.FromException<byte[]>(expected));
+
+        var actual = await Assert.ThrowsAsync<HttpRequestException>(() => harness.Plugin.PlayAudioAsync("hello"));
+
+        Assert.Same(expected, actual);
+        Assert.Single(harness.Http.Calls);
+        Assert.Empty(harness.Audio.Calls);
+    }
+
+    [Fact]
+    public async Task PlayAudioAsync_HttpCancellation_PropagatesCancellationWithoutPlaybackOrRetry()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var harness = CreateHarness(
+            new EdgeSettings(),
+            (_, token) => Task.FromCanceled<byte[]>(token));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => harness.Plugin.PlayAudioAsync("hello", cancellation.Token));
+
+        var call = Assert.Single(harness.Http.Calls);
+        Assert.Equal(cancellation.Token, call.CancellationToken);
+        Assert.Empty(harness.Audio.Calls);
+    }
+
+    private static TestHarness CreateHarness(
+        EdgeSettings settings,
+        Func<int, CancellationToken, Task<byte[]>>? postBehavior = null)
+    {
+        var http = new HttpRecorder(postBehavior);
+        var audio = new AudioRecorder();
+        var context = CreateProxy<IPluginContext>((method, _) => method.Name switch
+        {
+            "get_HttpService" => http.Proxy,
+            "get_AudioPlayer" => audio.Proxy,
+            "LoadSettingStorage" when method.IsGenericMethod
+                && method.GetGenericArguments()[0] == typeof(EdgeSettings) => settings,
+            "Dispose" => null,
+            _ => throw new NotSupportedException($"Unexpected IPluginContext call: {method}")
+        });
+        var plugin = new EdgeMain();
+        plugin.Init(context);
+        return new TestHarness(plugin, http, audio);
+    }
+
+    private static void AssertNoOrigin(Options? options)
+    {
+        Assert.True(options?.Headers is null || !options.Headers.ContainsKey("Origin"));
+    }
+
+    private static T CreateProxy<T>(Func<MethodInfo, object?[]?, object?> handler) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, DelegateDispatchProxy>();
+        ((DelegateDispatchProxy)(object)proxy).Handler = handler;
+        return proxy;
+    }
+
+    private sealed record TestHarness(EdgeMain Plugin, HttpRecorder Http, AudioRecorder Audio);
+
+    private sealed record HttpCall(
+        string Url,
+        object Content,
+        Options? Options,
+        CancellationToken CancellationToken);
+
+    private sealed record AudioCall(byte[] AudioData, CancellationToken CancellationToken);
+
+    private sealed class HttpRecorder
+    {
+        private readonly Func<int, CancellationToken, Task<byte[]>> _postBehavior;
+
+        public HttpRecorder(Func<int, CancellationToken, Task<byte[]>>? postBehavior)
+        {
+            _postBehavior = postBehavior ?? ((_, _) => Task.FromResult<byte[]>([0x01]));
+            Proxy = CreateProxy<IHttpService>(Invoke);
+        }
+
+        public IHttpService Proxy { get; }
+
+        public List<HttpCall> Calls { get; } = [];
+
+        private object? Invoke(MethodInfo method, object?[]? arguments)
+        {
+            if (method.Name != nameof(IHttpService.PostAsBytesAsync)
+                || arguments is not { Length: 4 }
+                || arguments[0] is not string url
+                || arguments[1] is not object content
+                || arguments[3] is not CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException($"Unexpected IHttpService call: {method}");
+            }
+
+            Calls.Add(new HttpCall(url, content, arguments[2] as Options, cancellationToken));
+            return _postBehavior(Calls.Count, cancellationToken);
+        }
+    }
+
+    private sealed class AudioRecorder
+    {
+        public AudioRecorder()
+        {
+            Proxy = CreateProxy<IAudioPlayer>(Invoke);
+        }
+
+        public IAudioPlayer Proxy { get; }
+
+        public List<AudioCall> Calls { get; } = [];
+
+        private object? Invoke(MethodInfo method, object?[]? arguments)
+        {
+            if (method.Name == nameof(IAudioPlayer.PlayAsync)
+                && arguments is [byte[] audioData, CancellationToken cancellationToken])
+            {
+                Calls.Add(new AudioCall(audioData, cancellationToken));
+                return Task.CompletedTask;
+            }
+
+            if (method.Name == nameof(IDisposable.Dispose))
+            {
+                return null;
+            }
+
+            throw new NotSupportedException($"Unexpected IAudioPlayer call: {method}");
+        }
+    }
+
+    public class DelegateDispatchProxy : DispatchProxy
+    {
+        public Func<MethodInfo, object?[]?, object?> Handler { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return Handler(targetMethod!, args);
+        }
+    }
+}

--- a/src/Tests/STranslate.Tests/STranslate.Tests.csproj
+++ b/src/Tests/STranslate.Tests/STranslate.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\STranslate\STranslate.csproj" />
     <ProjectReference Include="..\..\Plugins\STranslate.Plugin.Ocr.OcrSpace\STranslate.Plugin.Ocr.OcrSpace.csproj" />
+    <ProjectReference Include="..\..\Plugins\STranslate.Plugin.Tts.MicrosoftEdge\STranslate.Plugin.Tts.MicrosoftEdge.csproj" />
     <ProjectReference Include="..\..\Plugins\STranslate.Plugin.Translate.OpenAI\STranslate.Plugin.Translate.OpenAI.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Refs #787

## 问题与修复

Issue #787 附件日志中的失败为 HTTP 403，正文是 `Forbidden`。v2.0.10 插件发送的五个 JSON 字段请求体及类型与[当前网页服务](https://tts.wangwangit.com)一致，但没有携带该站点的 Origin 请求头。

相同请求不带来源头时返回 403，只增加 `Origin: https://tts.wangwangit.com` 后返回音频。本 PR 在 Edge TTS 插件调用默认服务的 HTTPS/443 地址时添加这一请求头，使该请求能够通过当前观察到的来源检查。

## 改动范围

- 使用 `Uri.TryCreate` 解析目标地址，仅匹配 HTTPS、精确主机名 `tts.wangwangit.com`（忽略大小写）及默认 443 端口。
- 通过单次请求的 `Options.Headers` 添加 `Origin`，每次重新构造选项，避免切换地址后残留。
- 自定义地址沿用原调用行为；保持现有 JSON 请求体、音频播放接口与取消令牌传递。不修改共享 HTTP 客户端，不增加 Referer、重试或备用服务。
- Edge TTS 插件版本从 1.0.0 更新到 1.0.1；主程序、SDK、配置结构和公共接口不变。
- 新增插件入口的离线回归测试，不在自动化测试中调用公共 TTS 服务。

## 请求对照

北京时间 2026-09-07 09:24，使用 .NET HttpClient，固定插件配置的 Chrome/120 User-Agent、HTTP/1.1、`application/json; charset=utf-8` 和下面的请求体，仅改变 Origin：

```json
{"input":"hi","voice":"zh-CN-XiaoxiaoNeural","speed":1,"pitch":"0","style":"general"}
```

| 请求头差异 | HTTP 状态 | Content-Type | 响应字节数 |
| --- | --- | --- | --- |
| 无 Origin / Referer | 403 | text/plain; charset=utf-8 | 9（Forbidden） |
| 增加 Origin: https://tts.wangwangit.com | 200 | audio/mpeg | 6624 |

这验证的是当前端点的 HTTP 行为；不据此推断来源检查的加入时间、具体代理配置，或原报告者机器上的全部运行条件。公网对照使用独立 HttpClient，不能替代整个桌面应用的实际播放验证。

## 本地验证

- [x] 修复前的默认地址测试能检出缺少 Origin。
- [x] 14 项 Edge TTS 定向测试通过：目标主机及 :443、非目标地址、切换 URL 时请求隔离、五字段请求体、音频字节与 token 传递、异常及取消传播。
- [x] `dotnet build src/STranslate.slnx --configuration Debug --verbosity minimal`：成功，0 错误。
- [x] `dotnet test src/Tests/STranslate.Tests/STranslate.Tests.csproj --configuration Debug --no-build --verbosity minimal`：288 通过，0 失败，0 跳过。
- [x] `git diff --check`：通过。

## 合并前需确认

**添加来源头会使原本被拒绝的桌面客户端请求获得放行，但我们尚不清楚服务提供方是否希望接受 STranslate 等第三方客户端的调用。**

来源检查可能用于限制站外调用或控制公共实例负载。如果这是提供方有意设置的使用边界，那么仅因技术上能够获得成功响应，并不足以说明应该合并此适配。

项目当前下载徽章约为 [4.1M](https://img.shields.io/github/downloads/ZGGSONG/STranslate/total)，且 Edge TTS 是当前唯一预装的 TTS 插件，因此潜在影响值得考虑。累计下载量并不等于活跃用户数或实际 TTS 请求量。

本 PR 先以草稿形式提供可审阅的修复与验证结果，建议维护者在合并前判断是否需要与服务提供方确认使用意图。尚未取得服务提供方认可，不将该补丁表述为已获其授权的集成方案。
