### PR TITLE
fix: preserve Compact window bounds on mixed-DPI secondary monitors

### DIFF
--- a/src/STranslate/Views/ImageTranslateCompactWindow.xaml.cs
+++ b/src/STranslate/Views/ImageTranslateCompactWindow.xaml.cs
@@ -83,6 +83,20 @@ public partial class ImageTranslateCompactWindow
         }
     }
 
+    protected override void OnContentRendered(EventArgs e)
+    {
+        base.OnContentRendered(e);
+
+        // HWND 首次创建时可能沿用主屏 DPI；SourceInitialized 内的物理定位会触发
+        // WPF 随后的 DPI 尺寸调整。等首轮布局完成后，重新同步已有的物理边界，
+        // 避免低 DPI 副屏上的窗口被二次缩小，裁掉图片和工具条。
+        if (!_isClosing && _layout is not null)
+        {
+            PlaceOnPhysicalWindowBounds(_layout.WindowBounds, GetDpiScale(_layout.WindowBounds));
+            ApplyLayoutToVisualTree();
+        }
+    }
+
     protected override void OnDeactivated(EventArgs e)
     {
         base.OnDeactivated(e);


### PR DESCRIPTION
Opening an image translation result in Compact mode on a lower-DPI secondary monitor can clip the image and place the toolbar outside the window. This reproduces on current upstream `main` (`1ee02821`).

### Reproduction

1. Use a 3840×2160 primary monitor at 250% scaling and a 1920×1080 secondary monitor at 100%, positioned to the left of the primary monitor.
2. Select Compact image translation mode and capture a region on the secondary monitor.
3. After processing, the result appears cropped and the toolbar is missing.

With a prepared 600×300 image, the unmodified production window ends up at 256×151 physical pixels, while its image control remains 600×300 and the toolbar starts 306 pixels below the window top. The content is clipped by the undersized outer window.

### Change

Only `src/STranslate/Views/ImageTranslateCompactWindow.xaml.cs` changes: **14 lines added, 0 removed**, including comments and blank lines. The fix reuses two existing layout helpers.

The initial physical positioning in `OnSourceInitialized` does not survive the subsequent DPI size adjustment in this mixed-DPI startup scenario. The new override resynchronizes the existing window bounds and child layout after the first content render. It does not recompute the layout or remeasure the toolbar.

The added override, with comments omitted, is:

```csharp
protected override void OnContentRendered(EventArgs e)
{
    base.OnContentRendered(e);

    if (!_isClosing && _layout is not null)
    {
        PlaceOnPhysicalWindowBounds(_layout.WindowBounds, GetDpiScale(_layout.WindowBounds));
        ApplyLayoutToVisualTree();
    }
}
```

The same 600×300 image now has a 641×378 outer window, fully containing the image and toolbar. The image and toolbar geometry remains unchanged.

### Validation

- Release build: zero warnings and errors; all 274 existing upstream tests pass.
- Compared unmodified `main` and the candidate using the compiled production Compact window with prepared bitmaps on the actual 250%/100% dual-monitor desktop; no OCR or translation services were invoked by this harness.
- Ten placement/size cases cover both monitors, screen edges, small and large images, and toolbar placement below, above, or over the image. All candidate images and toolbars fit within their windows; primary-monitor geometry is unchanged.
- Reapplying the render callback three times leaves geometry unchanged and produces no additional render-event loop. Controlled hide/show checks, with normal deactivation auto-close suppressed in the fixture, also preserve geometry.
- The no-layout and close-during-render-event cases complete without exceptions.

Note: Because this correction runs after the first content render, resizing the visible window can cause a brief flicker during initial display. A more complete solution may require changing the initialization order so that target-monitor DPI handling and layout synchronization finish before the window is shown.
