### PR TITLE
feat: Prompt 增加稳定 Id 字段（供插件持久化绑定）

### DIFF
--- a/src/STranslate.Plugin/Prompt.cs
+++ b/src/STranslate.Plugin/Prompt.cs
@@ -10,6 +10,12 @@ namespace STranslate.Plugin;
 public partial class Prompt : ObservableObject
 {
     /// <summary>
+    /// 唯一标识
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>
     /// 名称
     /// </summary>
     [ObservableProperty] public partial string Name { get; set; }
@@ -31,6 +37,7 @@ public partial class Prompt : ObservableObject
     {
         Name = "New Prompt";
         IsEnabled = false;
+        // Id 保持 null，等待 JSON 填充或插件迁移补齐
     }
 
     /// <summary>
@@ -41,6 +48,7 @@ public partial class Prompt : ObservableObject
     /// <param name="isEnabled"></param>
     public Prompt(string name, IEnumerable<PromptItem> prompts, bool isEnabled = false)
     {
+        Id = Guid.NewGuid().ToString("N");
         Name = name;
         IsEnabled = isEnabled;
         foreach (var prompt in prompts)
@@ -55,7 +63,9 @@ public partial class Prompt : ObservableObject
     /// <returns></returns>
     public Prompt Clone()
     {
-        return new Prompt(Name, Items.Select(p => p.Clone()), IsEnabled);
+        var clone = new Prompt(Name, Items.Select(p => p.Clone()), IsEnabled);
+        clone.Id = Id;
+        return clone;
     }
 }
 

--- a/src/STranslate/ViewModels/PromptEditViewModel.cs
+++ b/src/STranslate/ViewModels/PromptEditViewModel.cs
@@ -158,6 +158,8 @@ public partial class PromptEditViewModel : ObservableObject, IDisposable
         {
             // 克隆选中的 Prompt
             var copiedPrompt = SelectedPrompt.Clone();
+            // 复制的新 Prompt 生成独立 Id（Clone 保留原 Id，必须显式覆盖）
+            copiedPrompt.Id = Guid.NewGuid().ToString("N");
 
             // 生成唯一的名字
             var newName = GenerateUniqueName(SelectedPrompt.Name + _i18n.GetTranslation("NewPromptSuffix"));


### PR DESCRIPTION
### 描述

#### 背景 / Background

当前 `Prompt` 类型（`src/STranslate.Plugin/Prompt.cs`）仅以 `Name` 作为标识，存在以下问题：

1. **不校验重名**：多个 Prompt 可以同名，无法区分
2. **复制后内容改名，Id 缺失**：复制 Prompt 后改内容不改名，会出现两个同名 Prompt
3. **重命名后关联失效**：基于 `Name` 建立的持久关联（如插件绑定）会随改名而失效
4. **索引不稳定**：若用列表索引关联，用户增删排序后全部错位

这导致任何需要"稳定引用某个 Prompt"的场景（如插件将 Prompt 与外部配置做持久绑定）都无法可靠实现。

#### 解决方案 / Solution

给 `Prompt` 增加一个稳定的唯一标识字段 `Id`：

```csharp
[JsonPropertyName("id")]
public string? Id { get; set; }
```

**设计要点：**

| 场景 | 行为 |
|------|------|
| 新建 Prompt（`new Prompt(...)`） | 带参构造函数自动生成 Id |
| 反序列化（JSON 有 id） | 使用 JSON 中的 Id |
| 反序列化（JSON 无 id，老配置） | Id 为 null（可检测并迁移） |
| `Clone()` | 保留原 Id |
| `CopyPrompt()` | 显式重生成新 Id |

**关键设计决策：**

1. **Id 为可空类型（`string?`）**：有意设计。反序列化老配置（无 id 字段）时走无参构造函数，Id 保持 `null`，供插件检测"这是老配置"并触发迁移。这是解决"老配置 Id 每次加载都变"问题的前提——如果直接在属性初始化器生成 Id，插件将永远检测不到老配置。

2. **`Clone()` 保留原 Id**：用于运行时读取副本时保持身份一致；需要"复制为新 Prompt"时，调用方必须显式覆盖新 Id（如 `CopyPrompt()` 中的做法）。

3. **不强制迁移，不主动写盘**：SDK 只提供 Id 能力，迁移是使用方（插件）的自由。不想用 Id 的插件完全无感；想用 Id 做持久绑定的插件，在 `Init()` 中补一次并写盘即可。

**插件迁移参考代码：**

```csharp
// 插件 Init() 中：检测并补全 Id，仅在必要时写盘
var needSave = false;
foreach (var p in Settings.Prompts)
    if (string.IsNullOrEmpty(p.Id))
    {
        p.Id = Guid.NewGuid().ToString("N");
        needSave = true;
    }
if (needSave) Context.SaveSettingStorage<Settings>();
```

#### 改动范围 / Changes

**仅 2 个文件：**

| 文件 | 改动 |
|------|------|
| `src/STranslate.Plugin/Prompt.cs` | 新增 `Id` 属性、无参构造不生成、带参构造生成、`Clone()` 保留原 Id |
| `src/STranslate/ViewModels/PromptEditViewModel.cs` | `CopyPrompt()` 中显式重生成新 Id（1 行） |

**未改动：**
- 宿主其他代码（`Settings.cs`、`PluginContext`、`StorageBase` 等）
- 任何插件仓库
- `PromptItem`
- 序列化配置
- UI

#### 兼容性 / Compatibility

- **老配置（无 id 字段）**：反序列化后 Id 为 `null`，插件可检测；用户下次自然保存时写盘，或插件主动补一次并写盘
- **新配置（有 id 字段）**：正常读写，Id 保留
- **不主动 `SaveSettingStorage`**：避免"加载即写盘"意外覆盖用户文件
- **影响**：对现有插件完全无感（新字段、可选、默认 null）

#### 验证 / Verification

已通过 **Windows 实机运行验证**（临时日志 + 实机操作）：

| 验证项 | 结果 |
|--------|------|
| 新建 Prompt 有 Id | ✅ |
| 复制 Prompt 生成新 Id | ✅ |
| Clone 保留原 Id | ✅ |
| 老配置反序列化 Id=null | ✅ |
| 保存后重启 Id 稳定 | ✅ |
| 编译（Debug） | ✅ 0 警告 0 错误 |

#### 关闭的 Issue / Closes

Closes #800
