### PR TITLE
fix: 修复 Acrobat 中鼠标划词不触发

### DIFF
--- a/src/STranslate/Helpers/AcrobatCursorCompatibility.cs
+++ b/src/STranslate/Helpers/AcrobatCursorCompatibility.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace STranslate.Helpers;
+
+internal sealed class AcrobatCursorCompatibility
+{
+    [StructLayout(LayoutKind.Sequential)] struct IconInfo { public int IsIcon; public uint X, Y; public IntPtr Mask, Color; }
+    [StructLayout(LayoutKind.Sequential)] struct BitmapInfo { public int Type, Width, Height, WidthBytes; public ushort Planes, BitsPixel; public IntPtr Bits; }
+    [DllImport("user32.dll")] static extern bool GetIconInfo(IntPtr cursor, out IconInfo info);
+    [DllImport("user32.dll")] static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint pid);
+    [DllImport("gdi32.dll", EntryPoint="GetObjectW")] static extern int GetObject(IntPtr bitmap, int size, out BitmapInfo info);
+    [DllImport("gdi32.dll")] static extern int GetBitmapBits(IntPtr bitmap, int count, byte[] data);
+    [DllImport("gdi32.dll")] static extern bool DeleteObject(IntPtr obj);
+
+    // 从 Acrobat 文字选择光标采集的已知位图指纹，避免依赖进程重启后会变化的句柄。
+    private const string TextCursorFingerprint = "6:12:37x37x1-1207FBF437A6D60BAD608C9C4A7397194C4F3768142A32C7E5F3A1415452A992:37x37x32-8B594E3DDBF4F7ADCB4EA9DB36D5FE599C6C336AC46A4CFC4E166D5C862A1B60";
+    // 同一光标在 PerMonitorV2 实际拖选中读到 56×56，需与 37×37 样本分别匹配。
+    private const string PerMonitorTextCursorFingerprint = "9:18:56x56x1-5C55C8F4DB4010BA9203D83536D0609856AF8C847AC039E37E7DDE8FBD574B61:56x56x32-5600571C565EC241354317B795788BB262735B4026608F2F58B283C813B692AF";
+    private const int CacheLifetimeMs = 2000;
+    private readonly Func<uint> _getForegroundProcessId;
+    private readonly Func<uint, string> _getProcessName;
+    private readonly Func<IntPtr, string> _getFingerprint;
+    private readonly Func<long> _getTimestamp;
+    private IntPtr _lastCursor;
+    private bool _lastCursorMatches;
+    private uint _lastPid;
+    private bool _lastProcessMatches;
+    private long _lastProcessCheck;
+    private long _lastCursorCheck;
+    private bool _hasProcessCache;
+    private bool _hasCursorCache;
+
+    public AcrobatCursorCompatibility() : this(GetForegroundProcessId, GetProcessName, Fingerprint, () => Environment.TickCount64)
+    {
+    }
+
+    internal AcrobatCursorCompatibility(Func<uint> getForegroundProcessId, Func<uint, string> getProcessName,
+        Func<IntPtr, string> getFingerprint, Func<long> getTimestamp)
+    {
+        _getForegroundProcessId = getForegroundProcessId;
+        _getProcessName = getProcessName;
+        _getFingerprint = getFingerprint;
+        _getTimestamp = getTimestamp;
+    }
+
+    // 仅由鼠标 Hook 线程调用；缓存属于当前服务实例，不跨实例共享。
+    public bool IsTextCursor(IntPtr cursor)
+    {
+        if (cursor == IntPtr.Zero)
+            return false;
+
+        try
+        {
+            var pid = _getForegroundProcessId();
+            if (pid == 0)
+                return false;
+
+            var now = _getTimestamp();
+            if (!_hasProcessCache || pid != _lastPid || now - _lastProcessCheck >= CacheLifetimeMs)
+            {
+                if (pid != _lastPid)
+                    _hasCursorCache = false;
+                _hasProcessCache = true;
+                _lastProcessCheck = now;
+                _lastPid = pid;
+                _lastProcessMatches = false;
+                _lastProcessMatches = IsAcrobatProcess(_getProcessName(pid));
+            }
+
+            if (!_lastProcessMatches)
+                return false;
+
+            if (!_hasCursorCache || cursor != _lastCursor || now - _lastCursorCheck >= CacheLifetimeMs)
+            {
+                _hasCursorCache = true;
+                _lastCursorCheck = now;
+                _lastCursor = cursor;
+                _lastCursorMatches = false;
+                _lastCursorMatches = MatchesFingerprint(_getFingerprint(cursor));
+            }
+
+            return _lastCursorMatches;
+        }
+        catch
+        {
+            // 进程退出、无权读取或 GDI 读取失败时不把普通拖动当作划词。
+            return false;
+        }
+    }
+
+    private static uint GetForegroundProcessId()
+    {
+        GetWindowThreadProcessId(GetForegroundWindow(), out uint pid);
+        return pid;
+    }
+
+    private static string GetProcessName(uint pid)
+    {
+        using var process = Process.GetProcessById(checked((int)pid));
+        return process.ProcessName;
+    }
+    internal static bool IsAcrobatProcess(string name) =>
+        string.Equals(name, "Acrobat", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "AcroRd32", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool MatchesFingerprint(string fingerprint) =>
+        string.Equals(fingerprint, TextCursorFingerprint, StringComparison.Ordinal) ||
+        string.Equals(fingerprint, PerMonitorTextCursorFingerprint, StringComparison.Ordinal);
+    public static string Fingerprint(IntPtr cursor)
+    {
+        if (!GetIconInfo(cursor, out var icon)) return "";
+        try { return icon.X + ":" + icon.Y + ":" + BitmapFingerprint(icon.Mask) + ":" + BitmapFingerprint(icon.Color); }
+        finally { if (icon.Mask != IntPtr.Zero) DeleteObject(icon.Mask); if (icon.Color != IntPtr.Zero) DeleteObject(icon.Color); }
+    }
+
+    static string BitmapFingerprint(IntPtr bitmap)
+    {
+        if (bitmap == IntPtr.Zero) return "none";
+        if (GetObject(bitmap, Marshal.SizeOf<BitmapInfo>(), out var info) == 0) return "error";
+        int length = checked(Math.Abs(info.Height) * info.WidthBytes);
+        if (length <= 0 || length > 1048576) return "error";
+        var data = new byte[length];
+        if (GetBitmapBits(bitmap, length, data) != length) return "error";
+        return info.Width + "x" + info.Height + "x" + info.BitsPixel + "-" + Convert.ToHexString(SHA256.HashData(data));
+    }
+}

--- a/src/STranslate/Services/MouseHookService.cs
+++ b/src/STranslate/Services/MouseHookService.cs
@@ -17,6 +17,7 @@ public sealed class MouseHookService(ILogger<MouseHookService> logger) : IMouseH
     private static readonly TimeSpan ThreadTransitionTimeout = TimeSpan.FromSeconds(2);
     private readonly Lock _stateLock = new();
     private readonly Lock _eventDispatchLock = new();
+    private readonly STranslate.Helpers.AcrobatCursorCompatibility _acrobatCursorCompatibility = new();
     private Task _eventDispatchTask = Task.CompletedTask;
     private Thread? _hookThread;
     private ManualResetEventSlim? _startupCompleted;
@@ -222,10 +223,12 @@ public sealed class MouseHookService(ILogger<MouseHookService> logger) : IMouseH
         return PInvoke.CallNextHookEx(HHOOK.Null, nCode, wParam, lParam);
     }
 
-    private bool IsIBeamCursor()
+    private unsafe bool IsIBeamCursor()
     {
         var cursorInfo = new CURSORINFO { cbSize = (uint)Marshal.SizeOf<CURSORINFO>() };
-        return PInvoke.GetCursorInfo(ref cursorInfo) && cursorInfo.hCursor == _iBeamCursor;
+        return PInvoke.GetCursorInfo(ref cursorInfo) &&
+            (cursorInfo.hCursor == _iBeamCursor ||
+             _acrobatCursorCompatibility.IsTextCursor((IntPtr)cursorInfo.hCursor.Value));
     }
 
     private void QueueEvent(Action callback)

--- a/src/Tests/STranslate.Tests/AcrobatCursorCompatibilityTests.cs
+++ b/src/Tests/STranslate.Tests/AcrobatCursorCompatibilityTests.cs
@@ -1,0 +1,132 @@
+using STranslate.Helpers;
+
+namespace STranslate.Tests;
+
+public class AcrobatCursorCompatibilityTests
+{
+    // 分别来自普通采样与 PerMonitorV2 下实际 Acrobat 拖选，不能互相代替。
+    private const string Text37 = "6:12:37x37x1-1207FBF437A6D60BAD608C9C4A7397194C4F3768142A32C7E5F3A1415452A992:37x37x32-8B594E3DDBF4F7ADCB4EA9DB36D5FE599C6C336AC46A4CFC4E166D5C862A1B60";
+    private const string Text56 = "9:18:56x56x1-5C55C8F4DB4010BA9203D83536D0609856AF8C847AC039E37E7DDE8FBD574B61:56x56x32-5600571C565EC241354317B795788BB262735B4026608F2F58B283C813B692AF";
+    private const string Other56 = "4:7:56x56x1-5C55C8F4DB4010BA9203D83536D0609856AF8C847AC039E37E7DDE8FBD574B61:56x56x32-58798ACC0383D7EB89B5CC523EBB1D2BEFE7A6F2EEE0F8F90019E3ABDEAC317B";
+
+    [Theory]
+    [InlineData(Text37, true)]
+    [InlineData(Text56, true)]
+    [InlineData(Other56, false)]
+    [InlineData("", false)]
+    [InlineData("error", false)]
+    public void MatchesOnlyKnownTextShapes(string fingerprint, bool expected)
+        => Assert.Equal(expected, AcrobatCursorCompatibility.MatchesFingerprint(fingerprint));
+
+    [Theory]
+    [InlineData("Acrobat", true)]
+    [InlineData("AcroRd32", true)]
+    [InlineData("ACROBAT", true)]
+    [InlineData("AcrobatHelper", false)]
+    [InlineData("msedge", false)]
+    [InlineData("", false)]
+    public void LimitsFallbackToAcrobat(string processName, bool expected)
+    {
+        var fixture = new Fixture { ProcessName = processName };
+        Assert.Equal(expected, fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.Equal(expected ? 1 : 0, fixture.FingerprintReads);
+    }
+
+    [Fact]
+    public void DoesNotReadProcessesOrBitmapsForNullCursor()
+    {
+        var fixture = new Fixture();
+        Assert.False(fixture.Detector.IsTextCursor(IntPtr.Zero));
+        Assert.Equal(0, fixture.ProcessReads);
+        Assert.Equal(0, fixture.FingerprintReads);
+    }
+
+    [Fact]
+    public void CachesRepeatedReadsAndRefreshesReusedHandles()
+    {
+        var fixture = new Fixture();
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        fixture.Fingerprint = Other56;
+        fixture.Time = 1999;
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.Equal(1, fixture.FingerprintReads);
+        fixture.Time = 2000;
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.Equal(2, fixture.FingerprintReads);
+        Assert.Equal(2, fixture.ProcessReads);
+    }
+
+    [Fact]
+    public void SwitchingProcessesInvalidatesCursorCache()
+    {
+        var fixture = new Fixture();
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        fixture.Pid++;
+        fixture.Fingerprint = Other56;
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.Equal(2, fixture.FingerprintReads);
+    }
+
+    [Fact]
+    public void RechecksReusedProcessIds()
+    {
+        var fixture = new Fixture();
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        fixture.ProcessName = "notepad";
+        fixture.Time = 2000;
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.Equal(1, fixture.FingerprintReads);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FailedRefreshDoesNotReuseSuccessfulResult(bool processFailure)
+    {
+        var fixture = new Fixture();
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        fixture.Time = 2000;
+        fixture.FailProcessRead = processFailure;
+        fixture.FailFingerprintRead = !processFailure;
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)1));
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)1));
+    }
+
+    [Fact]
+    public void NewCursorHandleIsCheckedImmediately()
+    {
+        var fixture = new Fixture();
+        Assert.True(fixture.Detector.IsTextCursor((IntPtr)1));
+        fixture.Fingerprint = Other56;
+        Assert.False(fixture.Detector.IsTextCursor((IntPtr)2));
+        Assert.Equal(2, fixture.FingerprintReads);
+    }
+
+    private sealed class Fixture
+    {
+        public uint Pid = 1;
+        public string ProcessName = "Acrobat";
+        public string Fingerprint = Text56;
+        public long Time;
+        public int ProcessReads;
+        public int FingerprintReads;
+        public bool FailProcessRead;
+        public bool FailFingerprintRead;
+        public AcrobatCursorCompatibility Detector { get; }
+
+        public Fixture()
+        {
+            Detector = new(() => Pid, _ =>
+            {
+                ProcessReads++;
+                if (FailProcessRead) throw new InvalidOperationException();
+                return ProcessName;
+            }, _ =>
+            {
+                FingerprintReads++;
+                if (FailFingerprintRead) throw new InvalidOperationException();
+                return Fingerprint;
+            }, () => Time);
+        }
+    }
+}

--- a/src/docs/flow-input-trigger.md
+++ b/src/docs/flow-input-trigger.md
@@ -60,6 +60,13 @@
 - 鼠标划词：拖选和双击选词共用同一条完成事件链路。`IsMouseSelectionTranslationEnabled` 和 `IsMouseSelectionIconEnabled` 是独立开关，任意一个开启都会维持同一个 Hook。处理优先级为增量翻译、直接翻译、悬浮图标；两者同时开启时直接翻译，不显示图标。
 - 剪贴板监听：`ClipboardMonitor` 收到 `WM_CLIPBOARDUPDATE` 后读取文本，触发 `OnClipboardTextChanged -> ExecuteTranslate()`。
 
+### Acrobat 自定义文字光标兼容
+- `MouseHookService.IsIBeamCursor()` 保留系统 `IDC_IBEAM` 句柄匹配；不匹配时，`AcrobatCursorCompatibility` 仅对前台进程 `Acrobat` / `AcroRd32` 检查已知文字光标位图指纹。
+- 当前样本覆盖同一 Acrobat 文字光标的 37×37 与 56×56 版本。后者来自与主程序相同的 PerMonitorV2 环境下实际拖选；不能把不同 DPI 上下文采集的指纹视为相同。其他版本、主题和缩放仍需实测，不对任意自定义光标放宽限制。
+- 进程名和光标结果缓存最多 2 秒，前台进程或光标改变时刷新；进程退出、读取失败及未知位图均返回不匹配。`GetIconInfo` 创建的位图在 `finally` 中释放。
+- 仍使用原有拖选/双击阈值、取词超时与服务分发。不修改 Acrobat 首选项，也不采集或记录文档正文。
+- 回归验证：开启鼠标划词，在可复制 PDF 中拖选/双击；确认 Acrobat 文字光标触发、其他拖动不误触发，并检查 Foxit/浏览器的标准光标路径。自动测试同时覆盖进程限制、DPI 样本、缓存失效和读取异常。
+
 ### 触发后的窗口置前
 - 全局热键由 STranslate 接收并不代表 STranslate 已是前台应用；触发时浏览器、编辑器或 Explorer 通常仍持有前台窗口。
 - `ExecuteTranslate()`、`InputClear()` 及其他显示入口最终统一调用 `Win32Helper.ActivateForegroundWindow()`，再执行 WPF `Activate()` / `Focus()`。


### PR DESCRIPTION
## 问题与修复

在 Adobe Acrobat 的可复制 PDF 中，鼠标拖选后无法自动翻译，但手动复制和“划词翻译”快捷键正常；同一环境下 Foxit 和普通应用可以正常划词。

原来的 `IsIBeamCursor()` 只比较当前光标句柄与系统 `IDC_IBEAM`。Acrobat 使用自定义 I 形文字光标，因此拖选/双击不会进入划词完成事件。此改动保留标准光标路径，增加仅限前台进程 `Acrobat` / `AcroRd32` 的已知文字光标位图指纹匹配。

- 包含实际采样的 37×37 和 56×56 两种文字光标；后者来自与 WPF 应用相同的 PerMonitorV2 环境下实际拖选。同一光标在不同 DPI 上下文采样得到的指纹不能混用。
- 按服务实例缓存进程与光标识别结果，最多 2 秒；切换进程、改变光标和缓存到期时重新检查，避免每次移动都读取位图。
- 读取异常或未知指纹按不匹配处理，释放 `GetIconInfo` 创建的 GDI 位图。
- 保留原有手势阈值、取词超时和翻译分发；不修改 Acrobat 首选项、不采集正文。
- 在输入触发文档中补充适配范围、复现及回归方法。

## 验证

```powershell
dotnet test src/Tests/STranslate.Tests/STranslate.Tests.csproj -c Release --filter "FullyQualifiedName~AcrobatCursorCompatibilityTests|FullyQualifiedName~MouseSelection"
```

基于当前 main（`fa640384`）构建，43 项相关测试全部通过。覆盖进程范围、两种 DPI 样本、未知光标、缓存刷新、句柄/PID 复用和读取失败，以及现有鼠标划词测试。构建环境无法访问 NuGet 漏洞查询服务，产生 NU1900 警告；未修改依赖版本。

实机诊断中，实际 Acrobat 文字光标从原逻辑的“不匹配”变为补丁逻辑的“匹配”，其他采样光标仍不匹配。采用同一识别逻辑的本机补丁已由用户确认：Acrobat 直接拖选后可正常弹出译文。

## 适配范围

这是已知 Acrobat 光标的精确兼容补丁，不是任意自定义光标的通用分类器。目前只验证上述两种样本；不同 Acrobat 版本、主题和其他缩放比例仍需补充实测。保留严格匹配是为了避免把拖页或其他普通拖动当成划词。
